### PR TITLE
Fix #11 - Use OBA server time as "now" time

### DIFF
--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -24,10 +24,10 @@ import org.onebusaway.alexa.lib.ObaAgencies;
 import org.onebusaway.alexa.lib.ObaUserClient;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
+import org.onebusaway.io.client.request.ObaArrivalInfoResponse;
 import org.onebusaway.io.client.util.ArrivalInfo;
 
 import javax.annotation.Resource;
-import java.time.Instant;
 
 @NoArgsConstructor
 @Log4j
@@ -90,11 +90,12 @@ public class AuthedSpeechlet implements Speechlet {
     }
 
     private SpeechletResponse tellArrivals() {
-        ObaArrivalInfo[] arrivals = obaUserClient.getArrivalsAndDeparturesForStop(userData.getStopId());
+        ObaArrivalInfoResponse response = obaUserClient.getArrivalsAndDeparturesForStop(userData.getStopId());
+        ObaArrivalInfo[] arrivals = response.getArrivalInfo();
         StringBuilder sb = new StringBuilder();
         for (ObaArrivalInfo obaArrival: arrivals) {
             log.info("Arrival: " + obaArrival);
-            ArrivalInfo arrival = new ArrivalInfo(obaArrival, Instant.now().toEpochMilli());
+            ArrivalInfo arrival = new ArrivalInfo(obaArrival, response.getCurrentTime());
             sb.append(arrival.getLongDescription() + " -- "); //with pause between sentences
         }
         log.info("Full text output: " + sb.toString());

--- a/src/main/java/org/onebusaway/alexa/lib/ObaUserClient.java
+++ b/src/main/java/org/onebusaway/alexa/lib/ObaUserClient.java
@@ -17,7 +17,6 @@ package org.onebusaway.alexa.lib;
 
 import lombok.extern.log4j.Log4j;
 import org.onebusaway.io.client.ObaApi;
-import org.onebusaway.io.client.elements.ObaArrivalInfo;
 import org.onebusaway.io.client.elements.ObaStop;
 import org.onebusaway.io.client.request.ObaArrivalInfoRequest;
 import org.onebusaway.io.client.request.ObaArrivalInfoResponse;
@@ -90,12 +89,11 @@ public class ObaUserClient {
      * Returns the arrivals and departures for the given stopId
      *
      * @param stopId the stopId to return arrivals and departures for
-     * @return the arrivals and departures for the given stopId
+     * @return the arrival info response for the given stopId
      */
-    public ObaArrivalInfo[] getArrivalsAndDeparturesForStop(String stopId) {
+    public ObaArrivalInfoResponse getArrivalsAndDeparturesForStop(String stopId) {
         return new ObaArrivalInfoRequest.Builder(stopId)
                 .build()
-                .call()
-                .getArrivalInfo();
+                .call();
     }
 }


### PR DESCRIPTION
* Uses the timestamp recorded on the server and compares this to the estimated arrival info timestamp (also calculated on the server) to avoid clock sync issues, which could occur if the "now" time is produced by the client.  This also avoids potential time zone issues.

@philipmw Please review and merge if all looks good.