### PR TITLE
Add intent for getting current stop info

### DIFF
--- a/interaction model/schema.json
+++ b/interaction model/schema.json
@@ -25,6 +25,9 @@
       ]
     },
     {
+      "intent": "GetStopNumberIntent"
+    },
+    {
       "intent": "GetArrivalsIntent"
     }
   ]

--- a/interaction model/utterances.txt
+++ b/interaction model/utterances.txt
@@ -28,6 +28,27 @@ SetStopNumberIntent my stop code is {stopNumber}
 SetStopNumberIntent stop number is {stopNumber}
 SetStopNumberIntent my stop number is {stopNumber}
 
+GetStopNumberIntent what is my stop
+GetStopNumberIntent what is my current stop
+GetStopNumberIntent what is my stop name
+GetStopNumberIntent what is my stop code
+GetStopNumberIntent what is my current stop name
+GetStopNumberIntent what is my current stop code
+GetStopNumberIntent get my stop
+GetStopNumberIntent get my current stop
+GetStopNumberIntent get stop id
+GetStopNumberIntent get my stop id
+GetStopNumberIntent get stop code
+GetStopNumberIntent get my stop code
+GetStopNumberIntent get stop name
+GetStopNumberIntent get current stop name
+GetStopNumberIntent get my stop name
+GetStopNumberIntent get my current stop name
+GetStopNumberIntent get stop info
+GetStopNumberIntent get my stop info
+GetStopNumberIntent get current stop info
+GetStopNumberIntent get my current stop info
+
 GetArrivalsIntent where is my bus
 GetArrivalsIntent when is my bus
 GetArrivalsIntent where is the bus

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -24,6 +24,7 @@ import org.onebusaway.alexa.lib.ObaUserClient;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
 import org.onebusaway.io.client.request.ObaArrivalInfoResponse;
+import org.onebusaway.io.client.request.ObaStopResponse;
 import org.onebusaway.io.client.util.ArrivalInfo;
 
 import javax.annotation.Resource;
@@ -69,6 +70,8 @@ public class AuthedSpeechlet implements Speechlet {
             return SpeechletResponse.newTellResponse(out);
         } else if ("SetStopNumberIntent".equals(intent.getName())) {
             return anonSpeechlet.onIntent(request, session);
+        } else if ("GetStopNumberIntent".equals(intent.getName())) {
+            return getStopDetails();
         } else if ("GetArrivalsIntent".equals(intent.getName())) {
             return tellArrivals();
         } else {
@@ -93,6 +96,13 @@ public class AuthedSpeechlet implements Speechlet {
     public void onSessionEnded(final SessionEndedRequest request,
                                final Session session) {
 
+    }
+
+    private SpeechletResponse getStopDetails() throws SpeechletException {
+        ObaStopResponse stop = obaUserClient.getStopDetails(userData.getStopId());
+        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+        out.setText(String.format("Your stop is %s, %s.", stop.getStopCode(), stop.getName()));
+        return SpeechletResponse.newTellResponse(out);
     }
 
     private SpeechletResponse tellArrivals() {

--- a/src/main/java/org/onebusaway/alexa/lib/ObaUserClient.java
+++ b/src/main/java/org/onebusaway/alexa/lib/ObaUserClient.java
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.alexa.lib;
 
+import com.amazon.speech.speechlet.SpeechletException;
 import lombok.extern.log4j.Log4j;
 import org.onebusaway.io.client.ObaApi;
 import org.onebusaway.io.client.elements.ObaRegion;
@@ -87,6 +88,21 @@ public class ObaUserClient {
         log.debug("ObaStopsForLocationRequest returned " + response.toString());
         log.debug("  " + response.getStops().toString());
         return response.getStops();
+    }
+
+    /**
+     * Returns details about a particular stop, given it's stopId
+     * @param stopId
+     * @return details about a particular stop, given it's stopId
+     */
+    public ObaStopResponse getStopDetails(String stopId) throws SpeechletException {
+        ObaStopResponse response = new ObaStopRequest.Builder(stopId).build().call();
+        log.debug("ObaStopRequest returned " + response.toString());
+        if (response.getCode() == ObaApi.OBA_OK) {
+            return response;
+        } else {
+            throw new SpeechletException(String.format("Error getting stop details for %s", stopId));
+        }
     }
 
     /**

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -14,13 +14,13 @@ import org.onebusaway.alexa.lib.ObaUserClient;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
 import org.onebusaway.io.client.request.ObaArrivalInfoResponse;
+import org.onebusaway.io.client.request.ObaStopResponse;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import javax.annotation.Resource;
-
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
@@ -56,6 +56,31 @@ public class AuthedSpeechletTest {
     @Before
     public void initializeAuthedSpeechlet() throws URISyntaxException {
         authedSpeechlet.setUserData(testUserData);
+    }
+
+    @Test
+    public void getStopDetails(@Mocked ObaStopResponse mockResponse) throws SpeechletException, URISyntaxException {
+        new Expectations() {{
+            mockResponse.getStopCode(); result = "6497";
+            mockResponse.getName(); result = "University Area Transit Center";
+            obaUserClient.getStopDetails(anyString); result = mockResponse;
+        }};
+
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName("GetStopNumberIntent")
+                                        .withSlots(new HashMap<String, Slot>())
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        String spoken = ((PlainTextOutputSpeech)sr.getOutputSpeech()).getText();
+        assertThat(spoken, equalTo("Your stop is 6497, University Area Transit Center."));
     }
 
     @Test


### PR DESCRIPTION
Knocking off one more item for the commands we want to support in v1.0 (#3).  I decided not to persist stop code, and just hit the OBA REST API for fresh stop code and stop name info, based on the saved `stopId`.

@philipmw Please take a look.