### PR TITLE
Fix #45 - Add UX flow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ To both configure and use, just start with `open onebusaway`.
 
 Refer to `interaction model/utterances.txt` for the full list of spoken phrases we support.
 
+Our [user interface flow diagram](USER_INTERFACE_FLOW.md) also defined how you can interact with the skill.
+
 ## Develop ##
 
 The application backing the skill was designed to run in AWS.

--- a/USER_INTERFACE_FLOW.md
+++ b/USER_INTERFACE_FLOW.md
@@ -1,0 +1,7 @@
+## User Interface Flow ##
+
+We have documented the OneBusAway Alexa user interface flow in a [Google Drawing](https://docs.google.com/drawings/d/1TprMxlCym1Nn7LvDvH_Qqh7q6t0iDtRJgHwhPdQk5Vs/edit?usp=sharing).
+
+Here is a rendering of that drawing:
+
+![OneBusAway Alexa User Interface flow](https://docs.google.com/drawings/d/1TprMxlCym1Nn7LvDvH_Qqh7q6t0iDtRJgHwhPdQk5Vs/pub?w=2863&h=6659)


### PR DESCRIPTION
I've added a link to the UI flow diagram, and the rendering, as part of the markdown documentation.

The rendering will also automatically update itself as we modify the Google Drawing, as the Google Drawing automatically republishes itself.