### PR TITLE
Save repeat text when resetting region/stop

### DIFF
--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -247,6 +247,9 @@ public class AnonSpeechlet implements Speechlet {
         log.debug(String.format(
                 "Crupdating user with city %s and stop ID %s, code %s, regionId %d, regionName %s, obaBaseUrl %s.",
                 cityName, stop.getId(), stop.getStopCode(), region.getId(), region.getName(), region.getObaBaseUrl()));
+        String outText = String.format("Ok, your stop number is %s in the %s region. " +
+                        "Great.  I am ready to tell you about the next bus.",
+                stop.getStopCode(), region.getName());
         Optional<ObaUserDataItem> optUserData = obaDao.getUserData(session);
         if (optUserData.isPresent()) {
             ObaUserDataItem userData = optUserData.get();
@@ -255,6 +258,7 @@ public class AnonSpeechlet implements Speechlet {
             userData.setRegionId(region.getId());
             userData.setRegionName(region.getName());
             userData.setObaBaseUrl(region.getObaBaseUrl());
+            userData.setPreviousResponse(outText);
             obaDao.saveUserData(userData);
         } else {
             ObaUserDataItem userData = new ObaUserDataItem(
@@ -264,16 +268,14 @@ public class AnonSpeechlet implements Speechlet {
                     region.getId(),
                     region.getName(),
                     region.getObaBaseUrl(),
-                    "",
+                    outText,
                     null
             );
             obaDao.saveUserData(userData);
         }
 
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
-        out.setText(String.format("Ok, your stop number is %s in the %s region. " +
-                        "Great.  I am ready to tell you about the next bus.",
-                stop.getStopCode(), region.getName()));
+        out.setText(outText);
         return SpeechletResponse.newTellResponse(out);
     }
 


### PR DESCRIPTION
* Previously, if the user reset their region or stop, we didn't change the cached response field on this reset.  That could result in some strange behavior, such as the cached response still saying "You live in Seattle", even if the user just changed their city to Tampa.
* This patch sets the cached response to the text read after setup to ensure that the cached response always correctly represents the values that the user just set

@philipmw Please take a look.