### PR TITLE
Filter out arrivals / departures with negative ETA

### DIFF
--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -364,7 +364,7 @@ public class AnonSpeechlet implements Speechlet {
             throw new SpeechletException(e);
         }
 
-        String arrivalInfoText = SpeechUtil.getArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS, response.getCurrentTime());
+        String arrivalInfoText = SpeechUtil.prepareArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS, response.getCurrentTime());
 
         log.info("Full arrival text output: " + arrivalInfoText);
         String outText = String.format("Ok, your stop number is %s in the %s region. " +

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -177,7 +177,7 @@ public class AuthedSpeechlet implements Speechlet {
             throw new SpeechletException(e);
         }
 
-        String output = SpeechUtil.getArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS, response.getCurrentTime());
+        String output = SpeechUtil.prepareArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS, response.getCurrentTime());
 
         log.info("Full text output: " + output);
         saveOutputForRepeat(output);


### PR DESCRIPTION
Exclude arrival infos where ETA < 0 from Alexa's announcements (this indicates arrivals and departures which already happened).
