### PR TITLE
Fix #70 - Add summary text for predictions with same route/headsign

### DIFF
--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -19,6 +19,9 @@ package org.onebusaway.alexa.util;
 import lombok.extern.log4j.Log4j;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
 import org.onebusaway.io.client.util.ArrivalInfo;
+import org.onebusaway.io.client.util.UIUtils;
+
+import java.util.List;
 
 /**
  * Utilities for speech-related actions
@@ -40,13 +43,11 @@ public class SpeechUtil {
             output = "There are no upcoming arrivals at your stop for the next "
                     + arrivalScanMins + " minutes.";
         } else {
-            StringBuilder sb = new StringBuilder();
-            for (ObaArrivalInfo obaArrival: arrivals) {
-                log.info("Arrival: " + obaArrival);
-                ArrivalInfo arrival = new ArrivalInfo(obaArrival, currentTime, false);
-                sb.append(arrival.getLongDescription() + " -- "); //with pause between sentences
-            }
-            output = sb.toString();
+            List<ArrivalInfo> arrivalInfo = ArrivalInfo.convertObaArrivalInfo(arrivals, null,
+                    currentTime, false);
+            final String SEPARATOR = " -- "; // with pause between sentences
+            output = UIUtils.getArrivalInfoSummary(arrivalInfo, SEPARATOR);
+            log.info("ArrivalInfo: " + output);
         }
         return output;
     }

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -178,7 +178,7 @@ public class AuthedSpeechletTest {
                 session);
 
         String spoken = ((PlainTextOutputSpeech)sr.getOutputSpeech()).getText();
-        assertThat(spoken, equalTo("Route 8 Mlk Way Jr is now departing based on the schedule -- "));
+        assertThat(spoken, equalTo("Route 8 Mlk Way Jr is departing now based on the schedule -- "));
     }
 
     @Test
@@ -318,7 +318,7 @@ public class AuthedSpeechletTest {
             obaArrivalInfoResponse.getArrivalInfo(); result = obaArrivalInfoArray;
             obaUserClient.getArrivalsAndDeparturesForStop(anyString, anyInt); result = obaArrivalInfoResponse;
         }};
-        String response = "Route 8 Mlk Way Jr is now departing based on the schedule -- ";
+        String response = "Route 8 Mlk Way Jr is departing now based on the schedule -- ";
 
         // Test initial request/response - this should also save the response for later retrieval via repeat intent
         sr = authedSpeechlet.onLaunch(launchRequest, session);


### PR DESCRIPTION
* Uses new utility method in the `onebusaway-client-library`, implemented in https://github.com/OneBusAway/onebusaway-client-library/pull/17
* Utility method produces output text optimized for voice interfaces (e.g., Amazon Alexa) that groups prediction information for the same route/headsign - for example "Route 9 UATC to Downtown via 15th St is departing in 5, 35, 85, and 90 minutes", instead of listing each arrival separately and repeating the route/headsign.
* Split out scheduled and real-time predicted arrivals into separate groups, even if they are for the same route/headsign, so users can tell which are scheduled and which are real-time
* If only a single arrival exists for the route/headsign, then just output the normal summary text for that arrival info object
* Updates the unit tests for a small change in the summary text for single arrivals, which was made to make it easier to construct the group summary text

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Sign the [electronic OBA ICLA](https://docs.google.com/forms/d/12jV-ByyN186MuPotMvxJtNKtSaGGTnEHm8rXomM2bm4/viewform)

- [x] Apply the [OneBusAway style template](https://github.com/OneBusAway/onebusaway/wiki/Code-Style) to your code.

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.