### PR TITLE
Fix #67 - Support filtering arrivals by route for each stop

### DIFF
--- a/interaction model/schema.json
+++ b/interaction model/schema.json
@@ -56,6 +56,9 @@
     },
     {
       "intent": "DisableClockTime"
+    },
+    {
+      "intent": "SetRouteFilter"
     }
   ]
 }

--- a/interaction model/utterances.txt
+++ b/interaction model/utterances.txt
@@ -102,6 +102,13 @@ DisableClockTime disable clock times
 DisableClockTime turn off clock time
 DisableClockTime turn off clock times
 
+SetRouteFilter set a route filter
+SetRouteFilter set my route filter
+SetRouteFilter create a route filter
+SetRouteFilter create my route filter
+SetRouteFilter filter routes
+SetRouteFilter filter out routes
+
 GetArrivalsIntent where is my {TransitMode}
 GetArrivalsIntent where's my {TransitMode}
 GetArrivalsIntent when is my {TransitMode}

--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -384,9 +384,12 @@ public class AnonSpeechlet implements Speechlet {
             throw new SpeechletException(e);
         }
 
-        Long speakClockTime = (Long) session.getAttribute(CLOCK_TIME);
-        if (speakClockTime == null) {
-            speakClockTime = 0L;
+        Object speakClockTimeSessionObject = session.getAttribute(CLOCK_TIME);
+        Long speakClockTime = 0L;
+        if (speakClockTimeSessionObject instanceof Integer) {
+            // This happens if it's never been set before - ignore it
+        } else if (speakClockTimeSessionObject instanceof Long) {
+            speakClockTime = (Long) speakClockTimeSessionObject;
         }
 
         TimeZone timeZone;

--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -349,7 +349,9 @@ public class AnonSpeechlet implements Speechlet {
         log.debug(String.format(
                 "Crupdating user with city %s and stop ID %s, code %s, regionId %d, regionName %s, obaBaseUrl %s.",
                 cityName, stopId, stopCode, region.getId(), region.getName(), region.getObaBaseUrl()));
-
+        // Save the current Stop ID to the session so it can be used to pull the route filter
+        session.setAttribute(STOP_ID, stopId);
+        
         ObaArrivalInfoResponse response;
         try {
             response = obaUserClient.getArrivalsAndDeparturesForStop(

--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -140,7 +140,7 @@ public class AnonSpeechlet implements Speechlet {
 
                 if (askState == AskState.STOP_BEFORE_CITY) {
                     return setStopNumber(
-                            (String) session.getAttribute(STOP_NUMBER),
+                            (String) session.getAttribute(STOP_ID),
                             session);
                 } else {
                     PlainTextOutputSpeech out = new PlainTextOutputSpeech();
@@ -165,7 +165,7 @@ public class AnonSpeechlet implements Speechlet {
                 return SpeechletResponse.newAskResponse(out, stopNumReprompt);
             }
         } else if (SET_STOP_NUMBER.equals(intent.getName())) {
-            String stopNumberStr = intent.getSlot(STOP_NUMBER).getValue();
+            String stopNumberStr = intent.getSlot(STOP_ID).getValue();
             if (stopNumberStr == null) {
                 PlainTextOutputSpeech out = new PlainTextOutputSpeech();
                 out.setText("What is your stop number?");
@@ -329,7 +329,7 @@ public class AnonSpeechlet implements Speechlet {
     }
 
     private SpeechletResponse askForCityAfterStop(String spokenStopNumber, Session session) {
-        session.setAttribute(STOP_NUMBER, spokenStopNumber);
+        session.setAttribute(STOP_ID, spokenStopNumber);
         session.setAttribute(ASK_STATE, AskState.STOP_BEFORE_CITY.toString());
         PlainTextOutputSpeech citySpeech = new PlainTextOutputSpeech();
         citySpeech.setText(String.format("You haven't set your region yet. In what city is stop %s?", spokenStopNumber));
@@ -403,7 +403,7 @@ public class AnonSpeechlet implements Speechlet {
         if (routeFilters == null) {
             routeFilters = new HashMap<>();
         }
-        HashSet routesToFilter = routeFilters.get((String) session.getAttribute(STOP_NUMBER));
+        HashSet routesToFilter = routeFilters.get((String) session.getAttribute(STOP_ID));
 
         String arrivalInfoText = SpeechUtil.getArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS,
                 response.getCurrentTime(), speakClockTime, timeZone, routesToFilter);

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -249,7 +249,7 @@ public class AuthedSpeechlet implements Speechlet {
 
         List<ObaRoute> routes = response.getRoutes();
         if (routes.size() <= 1) {
-            String output = String.format("There is only one route for this stop, so I can't filter out any routes.");
+            String output = String.format("There is only one route for stop " + response.getStopCode() + ", so I can't filter out any routes.");
             saveOutputForRepeat(output);
             PlainTextOutputSpeech out = new PlainTextOutputSpeech();
             out.setText(output);

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -65,7 +65,7 @@ public class AuthedSpeechlet implements Speechlet {
     public SpeechletResponse onIntent(final IntentRequest request,
                                       final Session session)
             throws SpeechletException {
-        populateAttributes(session);
+        SpeechUtil.populateAttributes(session, userData);
         AskState askState = SpeechUtil.getAskState(session);
         session.setAttribute(ASK_STATE, AskState.NONE.toString());
 
@@ -113,7 +113,7 @@ public class AuthedSpeechlet implements Speechlet {
     public SpeechletResponse onLaunch(final LaunchRequest request,
                                       final Session session)
             throws SpeechletException {
-        populateAttributes(session);
+        SpeechUtil.populateAttributes(session, userData);
         return tellArrivals(session);
     }
 
@@ -125,40 +125,6 @@ public class AuthedSpeechlet implements Speechlet {
     @Override
     public void onSessionEnded(final SessionEndedRequest request,
                                final Session session) {
-    }
-
-    /**
-     * Populates the provided session with persisted user data, if the session attribute is empty
-     * @param session
-     */
-    private void populateAttributes(Session session) {
-        if (session.getAttribute(CITY_NAME) == null) {
-            session.setAttribute(CITY_NAME, userData.getCity());
-        }
-        if (session.getAttribute(STOP_ID) == null) {
-            session.setAttribute(STOP_ID, userData.getStopId());
-        }
-        if (session.getAttribute(REGION_ID) == null) {
-            session.setAttribute(REGION_ID, userData.getRegionId());
-        }
-        if (session.getAttribute(REGION_NAME) == null) {
-            session.setAttribute(REGION_NAME, userData.getRegionName());
-        }
-        if (session.getAttribute(OBA_BASE_URL) == null) {
-            session.setAttribute(OBA_BASE_URL, userData.getObaBaseUrl());
-        }
-        if (session.getAttribute(PREVIOUS_RESPONSE) == null) {
-            session.setAttribute(PREVIOUS_RESPONSE, userData.getPreviousResponse());
-        }
-        if (session.getAttribute(LAST_ACCESS_TIME) == null) {
-            session.setAttribute(LAST_ACCESS_TIME, userData.getLastAccessTime());
-        }
-        if (session.getAttribute(CLOCK_TIME) == null) {
-            session.setAttribute(CLOCK_TIME, userData.getSpeakClockTime());
-        }
-        if (session.getAttribute(TIME_ZONE) == null) {
-            session.setAttribute(TIME_ZONE, userData.getTimeZone());
-        }
     }
 
     private SpeechletResponse getCity() {

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -19,6 +19,7 @@ package org.onebusaway.alexa;
 import com.amazon.speech.slu.Intent;
 import com.amazon.speech.speechlet.*;
 import com.amazon.speech.ui.PlainTextOutputSpeech;
+import com.amazon.speech.ui.Reprompt;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j;
@@ -27,13 +28,15 @@ import org.onebusaway.alexa.lib.ObaUserClient;
 import org.onebusaway.alexa.storage.ObaDao;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.alexa.util.SpeechUtil;
+import org.onebusaway.io.client.elements.ObaRoute;
 import org.onebusaway.io.client.request.ObaArrivalInfoResponse;
 import org.onebusaway.io.client.request.ObaStopResponse;
+import org.onebusaway.io.client.util.UIUtils;
 
 import javax.annotation.Resource;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.TimeZone;
+import java.util.*;
 
 import static org.onebusaway.alexa.ObaIntent.*;
 import static org.onebusaway.alexa.SessionAttribute.*;
@@ -63,6 +66,8 @@ public class AuthedSpeechlet implements Speechlet {
                                       final Session session)
             throws SpeechletException {
         populateAttributes(session);
+        AskState askState = anonSpeechlet.getAskState(session);
+        session.setAttribute(ASK_STATE, AskState.NONE.toString());
 
         Intent intent = request.getIntent();
         if (HELP.equals(intent.getName())) {
@@ -84,17 +89,19 @@ public class AuthedSpeechlet implements Speechlet {
         } else if (SET_STOP_NUMBER.equals(intent.getName())) {
             return anonSpeechlet.onIntent(request, session);
         } else if (YES.equals(intent.getName())) {
-            return anonSpeechlet.onIntent(request, session);
+            return handleYesIntent(request, session, askState);
         } else if (NO.equals(intent.getName())) {
-            return anonSpeechlet.onIntent(request, session);
+            return handleNoIntent(request, session, askState);
         } else if (GET_STOP_NUMBER.equals(intent.getName())) {
             return getStopDetails();
         } else if (GET_ARRIVALS.equals(intent.getName())) {
-            return tellArrivals();
+            return tellArrivals(session);
         } else if (ENABLE_CLOCK_TIME.equals(intent.getName())) {
             return enableClockTime(session);
         } else if (DISABLE_CLOCK_TIME.equals(intent.getName())) {
             return disableClockTime(session);
+        } else if (SET_ROUTE_FILTER.equals(intent.getName())) {
+            return setRouteFilter(session);
         } else if (STOP.equals(intent.getName()) || CANCEL.equals(intent.getName())) {
             return goodbye();
         } else {
@@ -107,7 +114,7 @@ public class AuthedSpeechlet implements Speechlet {
                                       final Session session)
             throws SpeechletException {
         populateAttributes(session);
-        return tellArrivals();
+        return tellArrivals(session);
     }
 
     @Override
@@ -154,6 +161,9 @@ public class AuthedSpeechlet implements Speechlet {
         if (session.getAttribute(TIME_ZONE) == null) {
             session.setAttribute(TIME_ZONE, userData.getTimeZone());
         }
+        if (session.getAttribute(ROUTES_TO_FILTER) == null) {
+            session.setAttribute(ROUTES_TO_FILTER, userData.getRoutesToFilter());
+        }
     }
 
     private SpeechletResponse getCity() {
@@ -178,7 +188,7 @@ public class AuthedSpeechlet implements Speechlet {
         return SpeechletResponse.newTellResponse(out);
     }
 
-    private SpeechletResponse tellArrivals() throws SpeechletException {
+    private SpeechletResponse tellArrivals(Session session) throws SpeechletException {
         ObaArrivalInfoResponse response = null;
         try {
             response = obaUserClient.getArrivalsAndDeparturesForStop(
@@ -196,8 +206,14 @@ public class AuthedSpeechlet implements Speechlet {
             timeZone = TimeZone.getTimeZone(timeZoneText);
         }
 
+        HashMap<String, HashSet<String>> routeFilters = (HashMap<String, HashSet<String>>) session.getAttribute(ROUTES_TO_FILTER);
+        if (routeFilters == null) {
+            routeFilters = new HashMap<>();
+        }
+        HashSet routesToFilter = routeFilters.get(userData.getStopId());
+
         String output = SpeechUtil.getArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS,
-                response.getCurrentTime(), userData.getSpeakClockTime(), timeZone);
+                response.getCurrentTime(), userData.getSpeakClockTime(), timeZone, routesToFilter);
 
         log.info("Full text output: " + output);
         saveOutputForRepeat(output);
@@ -249,6 +265,158 @@ public class AuthedSpeechlet implements Speechlet {
         userData.setPreviousResponse(output);
         userData.setLastAccessTime(System.currentTimeMillis());
         obaDao.saveUserData(userData);
+    }
+
+    /**
+     * User asked to filter routes for the currently selected stop
+     *
+     * @param session
+     * @return
+     */
+    private SpeechletResponse setRouteFilter(final Session session) {
+        // Make sure we clear any existing routes to filter for this session (but leave any persisted)
+        session.setAttribute(DIALOG_ROUTES_TO_FILTER, null);
+
+        String stopId = (String) session.getAttribute(STOP_NUMBER);
+        String regionName = (String) session.getAttribute(REGION_NAME);
+        log.debug(String.format(
+                "Asked to set a route filter for stop ID %s in region %s...", stopId, regionName));
+
+        ObaStopResponse response;
+        try {
+            response = obaUserClient.getStop(stopId);
+        } catch (IOException e) {
+            log.error("Error getting details for stop + " + stopId + " in region " + regionName + ": " + e.getMessage());
+            return SpeechUtil.getCommunicationErrorMessage();
+        }
+
+        List<ObaRoute> routes = response.getRoutes();
+        if (routes.size() <= 1) {
+            String output = String.format("There is only one route for this stop, so I can't filter out any routes.");
+            saveOutputForRepeat(output);
+            PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+            out.setText(output);
+            return SpeechletResponse.newTellResponse(out);
+        }
+        // There is more than one route - ask user which they want to hear arrivals for
+        return askToFilterRoute(session, routes);
+    }
+
+    /**
+     * Ask the user if they want to hear arrivals for the first route, from the provided list of routes
+     *
+     * @param session
+     * @param routes  list of routes from which the first route will be taken
+     * @return response to be read to the user asking if they want to hear arrivals for the first route in the provided list of routes
+     */
+    private SpeechletResponse askToFilterRoute(Session session, List<ObaRoute> routes) {
+        PlainTextOutputSpeech askForRouteFilter = new PlainTextOutputSpeech();
+        String stopId = (String) session.getAttribute(STOP_NUMBER);
+        String routeName = "";
+
+        if (routes != null && routes.size() > 0) {
+            session.setAttribute(DIALOG_ROUTES_TO_ASK_ABOUT, routes);
+            routeName = UIUtils.getRouteDisplayName(routes.get(0));
+            askForRouteFilter.setText(String.format("Do you want to hear arrivals for %s for stop %s?", routeName, stopId));
+        } else {
+            ArrayList<ObaRoute> routesToAskAbout = (ArrayList<ObaRoute>) session.getAttribute(DIALOG_ROUTES_TO_ASK_ABOUT);
+            LinkedHashMap<String, String> routeData = (LinkedHashMap<String, String>) routesToAskAbout.get(0);
+            routeName = UIUtils.getRouteDisplayName(routeData.get("shortName"), routeData.get("longName"));
+            askForRouteFilter.setText(String.format("Ok, how about %s?", routeName));
+        }
+
+        Reprompt askForRouteFilterReprompt = new Reprompt();
+        PlainTextOutputSpeech repromptText = new PlainTextOutputSpeech();
+        repromptText.setText(String.format("Did you want to hear arrivals for %s for stop %s?", routeName, stopId));
+        askForRouteFilterReprompt.setOutputSpeech(repromptText);
+
+        session.setAttribute(ASK_STATE, AskState.FILTER_INDIVIDUAL_ROUTE.toString());
+        return SpeechletResponse.newAskResponse(askForRouteFilter, askForRouteFilterReprompt);
+    }
+
+    private SpeechletResponse handleYesIntent(final IntentRequest request,
+                                              final Session session, AskState askState) throws SpeechletException {
+        if (askState == AskState.VERIFYSTOP) {
+            // User confirmed that they want to select a particular stop - pass to anonSpeechlet to finish dialog
+            return anonSpeechlet.onIntent(request, session);
+        }
+
+        if (askState == AskState.FILTER_INDIVIDUAL_ROUTE) {
+            return handleFilterIndividualRoute(session, true);
+        }
+
+        log.error("Received yes intent without a question.");
+        return anonSpeechlet.askForCity(Optional.empty());
+    }
+
+    private SpeechletResponse handleNoIntent(final IntentRequest request,
+                                             Session session, AskState askState) throws SpeechletException {
+        if (askState == AskState.VERIFYSTOP) {
+            return anonSpeechlet.onIntent(request, session);
+        }
+
+        if (askState == AskState.FILTER_INDIVIDUAL_ROUTE) {
+            return handleFilterIndividualRoute(session, false);
+        }
+
+        log.error("Received no intent without a question.");
+        return anonSpeechlet.askForCity(Optional.empty());
+    }
+
+    /**
+     * User responded saying they did (hearArrivals==true) or did not (hearArrivals==false) want to hear arrivals for a
+     * particular stop (STOP_NUMBER of session) and a paricular route (the 0 index route in the SessionAttribute
+     * DIALOG_ROUTES_TO_ASK_ABOUT ArrayList)
+     *
+     * @param session
+     * @param hearArrivals true if the user wanted to hear arrivals about the 0 index route, false if they did not
+     * @return
+     * @throws SpeechletException
+     */
+    private SpeechletResponse handleFilterIndividualRoute(Session session, boolean hearArrivals) throws SpeechletException {
+        ArrayList<ObaRoute> routes = (ArrayList<ObaRoute>) session.getAttribute(DIALOG_ROUTES_TO_ASK_ABOUT);
+        if (routes == null) {
+            // Something went wrong
+            return SpeechUtil.getGeneralErrorMessage();
+        }
+        HashSet<String> routesToFilter = (HashSet<String>) session.getAttribute(DIALOG_ROUTES_TO_FILTER);
+        if (routesToFilter == null) {
+            routesToFilter = new HashSet<>();
+        }
+
+        // Get the last route we asked about - there should be at least one
+        LinkedHashMap<String, String> routeData = (LinkedHashMap<String, String>) routes.get(0);
+
+        if (!hearArrivals) {
+            // The user doesn't want to hear arrivals for this route, so add the routeId to set of route filters
+            routesToFilter.add(routeData.get("id"));
+            session.setAttribute(DIALOG_ROUTES_TO_FILTER, routesToFilter);
+        }
+
+        // Remove route we just asked about, so we can ask about the next one (if there are any left)
+        routes.remove(0);
+
+        if (routes.size() > 0) {
+            // Ask about the next route
+            session.setAttribute(DIALOG_ROUTES_TO_ASK_ABOUT, routes);
+            return askToFilterRoute(session, null);
+        }
+
+        // We've asked about all routes for this stop, so persist the route filter
+        String stopId = (String) session.getAttribute(STOP_NUMBER);
+        HashMap<String, HashSet<String>> persistedRouteFilter = userData.getRoutesToFilter();
+        if (persistedRouteFilter == null) {
+            persistedRouteFilter = new HashMap<>();
+        }
+        persistedRouteFilter.put(stopId, routesToFilter);
+        userData.setRoutesToFilter(persistedRouteFilter);
+        obaDao.saveUserData(userData);
+
+        String output = String.format("Alright, I've saved your route filter for your current stop %s.", stopId);
+        saveOutputForRepeat(output);
+        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+        out.setText(output);
+        return SpeechletResponse.newTellResponse(out);
     }
 
     /**

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Sean J. Barbeau (sjbarbeau@gmail.com),
+ * Copyright 2016-2017 Sean J. Barbeau (sjbarbeau@gmail.com),
  * Philip M. White (philip@mailworks.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ public class AuthedSpeechlet implements Speechlet {
                                       final Session session)
             throws SpeechletException {
         populateAttributes(session);
-        AskState askState = anonSpeechlet.getAskState(session);
+        AskState askState = SpeechUtil.getAskState(session);
         session.setAttribute(ASK_STATE, AskState.NONE.toString());
 
         Intent intent = request.getIntent();
@@ -103,7 +103,7 @@ public class AuthedSpeechlet implements Speechlet {
         } else if (SET_ROUTE_FILTER.equals(intent.getName())) {
             return setRouteFilter(session);
         } else if (STOP.equals(intent.getName()) || CANCEL.equals(intent.getName())) {
-            return goodbye();
+            return SpeechUtil.goodbye();
         } else {
             throw new SpeechletException("Did not recognize intent name");
         }
@@ -120,13 +120,11 @@ public class AuthedSpeechlet implements Speechlet {
     @Override
     public void onSessionStarted(final SessionStartedRequest request,
                                  final Session session) {
-
     }
 
     @Override
     public void onSessionEnded(final SessionEndedRequest request,
                                final Session session) {
-
     }
 
     /**
@@ -186,7 +184,7 @@ public class AuthedSpeechlet implements Speechlet {
     }
 
     private SpeechletResponse tellArrivals(Session session) throws SpeechletException {
-        ObaArrivalInfoResponse response = null;
+        ObaArrivalInfoResponse response;
         try {
             response = obaUserClient.getArrivalsAndDeparturesForStop(
                     userData.getStopId(),
@@ -261,10 +259,10 @@ public class AuthedSpeechlet implements Speechlet {
     }
 
     /**
-     * User asked to filter routes for the currently selected stop
+     * User asked to filter routes for the currently selected stop, so return the initial response
      *
      * @param session
-     * @return
+     * @return the initial response for setting a route filter
      */
     private SpeechletResponse setRouteFilter(final Session session) {
         // Make sure we clear any existing routes to filter for this session (but leave any persisted)
@@ -440,12 +438,5 @@ public class AuthedSpeechlet implements Speechlet {
             return lastOutput;
         }
         return "I'm sorry, I don't have anything to repeat.  You can ask me for arrival times for your stop.";
-    }
-
-    private SpeechletResponse goodbye() {
-        String output = String.format("Good-bye");
-        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
-        out.setText(output);
-        return SpeechletResponse.newTellResponse(out);
     }
 }

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -161,9 +161,6 @@ public class AuthedSpeechlet implements Speechlet {
         if (session.getAttribute(TIME_ZONE) == null) {
             session.setAttribute(TIME_ZONE, userData.getTimeZone());
         }
-        if (session.getAttribute(ROUTES_TO_FILTER) == null) {
-            session.setAttribute(ROUTES_TO_FILTER, userData.getRoutesToFilter());
-        }
     }
 
     private SpeechletResponse getCity() {
@@ -206,11 +203,7 @@ public class AuthedSpeechlet implements Speechlet {
             timeZone = TimeZone.getTimeZone(timeZoneText);
         }
 
-        HashMap<String, HashSet<String>> routeFilters = (HashMap<String, HashSet<String>>) session.getAttribute(ROUTES_TO_FILTER);
-        if (routeFilters == null) {
-            routeFilters = new HashMap<>();
-        }
-        HashSet routesToFilter = routeFilters.get(userData.getStopId());
+        HashSet routesToFilter = SpeechUtil.getRoutesToFilter(obaDao, session);
 
         String output = SpeechUtil.getArrivalText(response.getArrivalInfo(), ARRIVALS_SCAN_MINS,
                 response.getCurrentTime(), userData.getSpeakClockTime(), timeZone, routesToFilter);

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -368,7 +368,7 @@ public class AuthedSpeechlet implements Speechlet {
 
         // We've asked about all routes for this stop, so persist the route filter
         String stopId = (String) session.getAttribute(STOP_ID);
-        HashMap<String, HashSet<String>> persistedRouteFilter = userData.getRoutesToFilter();
+        HashMap<String, HashSet<String>> persistedRouteFilter = userData.getRoutesToFilterOut();
         if (persistedRouteFilter == null) {
             persistedRouteFilter = new HashMap<>();
         }
@@ -378,7 +378,7 @@ public class AuthedSpeechlet implements Speechlet {
             routesToFilterHashSet.add(routeId);
         }
         persistedRouteFilter.put(stopId, routesToFilterHashSet);
-        userData.setRoutesToFilter(persistedRouteFilter);
+        userData.setRoutesToFilterOut(persistedRouteFilter);
         obaDao.saveUserData(userData);
 
         String stopCode = (String) session.getAttribute(STOP_CODE);

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -297,6 +297,8 @@ public class AuthedSpeechlet implements Speechlet {
                                               final Session session, AskState askState) throws SpeechletException {
         if (askState == AskState.VERIFYSTOP) {
             // User confirmed that they want to select a particular stop - pass to anonSpeechlet to finish dialog
+            // Restore the session ASK_STATE
+            session.setAttribute(ASK_STATE, askState.toString());
             return anonSpeechlet.onIntent(request, session);
         }
 
@@ -311,6 +313,9 @@ public class AuthedSpeechlet implements Speechlet {
     private SpeechletResponse handleNoIntent(final IntentRequest request,
                                              Session session, AskState askState) throws SpeechletException {
         if (askState == AskState.VERIFYSTOP) {
+            // User said no to the current stop, so ask about the next one - pass to anonSpeechlet to finish dialog
+            // Restore the session ASK_STATE
+            session.setAttribute(ASK_STATE, askState.toString());
             return anonSpeechlet.onIntent(request, session);
         }
 

--- a/src/main/java/org/onebusaway/alexa/ObaIntent.java
+++ b/src/main/java/org/onebusaway/alexa/ObaIntent.java
@@ -27,6 +27,7 @@ public class ObaIntent {
     public static final String GET_ARRIVALS = "GetArrivalsIntent";
     public static final String ENABLE_CLOCK_TIME = "EnableClockTime";
     public static final String DISABLE_CLOCK_TIME = "DisableClockTime";
+    public static final String SET_ROUTE_FILTER = "SetRouteFilter";
     public static final String HELP = "AMAZON.HelpIntent";
     public static final String REPEAT = "AMAZON.RepeatIntent";
     public static final String STOP = "AMAZON.StopIntent";

--- a/src/main/java/org/onebusaway/alexa/SessionAttribute.java
+++ b/src/main/java/org/onebusaway/alexa/SessionAttribute.java
@@ -27,14 +27,18 @@ public class SessionAttribute {
     public static final String OBA_BASE_URL = "obaBaseUrl";
     public static final String PREVIOUS_RESPONSE = "previousResponse";
     public static final String LAST_ACCESS_TIME = "lastAccessTime";
-    public static final String FOUND_STOPS = "foundStops";
+    public static final String DIALOG_FOUND_STOPS = "foundStops";
     public static final String ASK_STATE = "askState";
     public static final String CLOCK_TIME = "clockTime";
     public static final String TIME_ZONE = "timeZone";
+    public static final String ROUTES_TO_FILTER = "routesToFilter";
+    public static final String DIALOG_ROUTES_TO_ASK_ABOUT = "foundRoutes";
+    public static final String DIALOG_ROUTES_TO_FILTER = "dialogRoutesToFilter";
 
     public enum AskState {
         NONE,
         VERIFYSTOP,
-        STOP_BEFORE_CITY
+        STOP_BEFORE_CITY,
+        FILTER_INDIVIDUAL_ROUTE
     }
 }

--- a/src/main/java/org/onebusaway/alexa/SessionAttribute.java
+++ b/src/main/java/org/onebusaway/alexa/SessionAttribute.java
@@ -37,7 +37,7 @@ public class SessionAttribute {
 
     // Strangely, we can't save HashSets or HashMaps to sessions (Amazon Alexa converts them to ArrayLists, which
     // generates a ClassCastException when trying to retrieve them.  This prevents us from saving route filters to sessions.
-    //public static final String ROUTES_TO_FILTER = "routesToFilter";
+    //public static final String ROUTES_TO_FILTER = "routesToFilterOut";
 
     public enum AskState {
         NONE,

--- a/src/main/java/org/onebusaway/alexa/SessionAttribute.java
+++ b/src/main/java/org/onebusaway/alexa/SessionAttribute.java
@@ -32,9 +32,12 @@ public class SessionAttribute {
     public static final String ASK_STATE = "askState";
     public static final String CLOCK_TIME = "clockTime";
     public static final String TIME_ZONE = "timeZone";
-    public static final String ROUTES_TO_FILTER = "routesToFilter";
     public static final String DIALOG_ROUTES_TO_ASK_ABOUT = "foundRoutes";
     public static final String DIALOG_ROUTES_TO_FILTER = "dialogRoutesToFilter";
+
+    // Strangely, we can't save HashSets or HashMaps to sessions (Amazon Alexa converts them to ArrayLists, which
+    // generates a ClassCastException when trying to retrieve them.  This prevents us from saving route filters to sessions.
+    //public static final String ROUTES_TO_FILTER = "routesToFilter";
 
     public enum AskState {
         NONE,

--- a/src/main/java/org/onebusaway/alexa/SessionAttribute.java
+++ b/src/main/java/org/onebusaway/alexa/SessionAttribute.java
@@ -21,7 +21,8 @@ package org.onebusaway.alexa;
  */
 public class SessionAttribute {
     public static final String CITY_NAME = "cityName";
-    public static final String STOP_NUMBER = "stopNumber";
+    public static final String STOP_ID = "stopNumber";
+    public static final String STOP_CODE = "stopCode";
     public static final String REGION_ID = "regionId";
     public static final String REGION_NAME = "regionName";
     public static final String OBA_BASE_URL = "obaBaseUrl";

--- a/src/main/java/org/onebusaway/alexa/lib/ObaUserClient.java
+++ b/src/main/java/org/onebusaway/alexa/lib/ObaUserClient.java
@@ -26,6 +26,7 @@ import org.onebusaway.location.Location;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Date;
 import java.util.TimeZone;
 
 @Log4j
@@ -148,6 +149,43 @@ public class ObaUserClient extends ObaClientSharedCode {
             return TimeZone.getTimeZone(timeZoneText);
         } else {
             throw new IOException(String.format("OBA Error %s getting timezone", response.getCode()));
+        }
+    }
+
+    /**
+     * Returns the full schedule for the given stopId and the given date (or the current date if date is null)
+     *
+     * @param stopId the stopId to return the schedule for
+     * @param date   the date to return the schedule for (or null if the current date should be used)
+     * @return the schedule for the given stop and day (or current date if date was null)
+     */
+    public ObaScheduleForStopResponse getScheduleForStop(@NonNull String stopId,
+                                                         Date date) throws IOException {
+        ObaScheduleForStopRequest.Builder requestBuilder = new ObaScheduleForStopRequest.Builder(stopId);
+        if (date != null) {
+            requestBuilder.setDate(date);
+        }
+        ObaScheduleForStopResponse response = requestBuilder.build().call();
+        if (response.getCode() == ObaApi.OBA_OK) {
+            return response;
+        } else {
+            throw new IOException(String.format("OBA Error %s getting full schedule for stop %s", response.getCode(), stopId));
+        }
+    }
+
+    /**
+     * Returns stop information for the given stopId
+     *
+     * @param stopId the stopId to return details for
+     * @return details for the given stopId
+     */
+    public ObaStopResponse getStop(@NonNull String stopId) throws IOException {
+        ObaStopResponse response = new ObaStopRequest.Builder(stopId).build().call();
+        log.debug("ObaStopRequest returned " + response.toString());
+        if (response.getCode() == ObaApi.OBA_OK) {
+            return response;
+        } else {
+            throw new IOException(String.format("OBA Error %s getting details for stop %s", response.getCode(), stopId));
         }
     }
 }

--- a/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
+++ b/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
@@ -100,8 +100,8 @@ public class ObaUserDataItem {
      */
     @Getter
     @Setter
-    @DynamoDBAttribute(attributeName = "RouteFilters")
-    private HashMap<String, HashSet<String>> routesToFilter;
+    @DynamoDBAttribute(attributeName = "RoutesToFilterOut")
+    private HashMap<String, HashSet<String>> routesToFilterOut;
 
     @DynamoDBVersionAttribute
     private Long version;

--- a/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
+++ b/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
@@ -25,6 +25,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.HashMap;
+import java.util.HashSet;
+
 /**
  * Model representing an item of the User Data table in DynamoDB for the
  * OneBusAway skill.
@@ -89,6 +92,16 @@ public class ObaUserDataItem {
     @Setter
     @DynamoDBAttribute(attributeName = "TimeZone")
     private String timeZone;
+
+    /**
+     * A set of stops (stop_id is the key) that are each mapped to a set of routeIds that should NOT
+     * be read to the user.  routeIds can change when GTFS data changes, so we need to allow new routeIds to surface if
+     * they haven't been seen before, and then the user can choose to filter them out.
+     */
+    @Getter
+    @Setter
+    @DynamoDBAttribute(attributeName = "RouteFilters")
+    private HashMap<String, HashSet<String>> routesToFilter;
 
     @DynamoDBVersionAttribute
     private Long version;

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -98,7 +98,7 @@ public class SpeechUtil {
             final String SEPARATOR = " -- "; // with pause between sentences
             output = UIUtils.getArrivalInfoSummary(arrivalInfo, SEPARATOR, clockTimeBool, timeZone, routesToFilter);
             if (TextUtils.isEmpty(output)) {
-                // If all routes currently running routes were filtered out, use no arrivals messsage
+                // If all currently running routes were filtered out, provide no arrivals message
                 output = noArrivals;
             }
             log.info("ArrivalInfo: " + output);

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -124,7 +124,7 @@ public class SpeechUtil {
                 String stopId = (String) session.getAttribute(STOP_ID);
                 if (stopId == null) {
                     // Try to get Stop ID from DAO
-                    optUserData.get().getStopId();
+                    stopId = optUserData.get().getStopId();
                 }
                 return routeFilters.get(stopId);
             }

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -88,7 +88,7 @@ public class SpeechUtil {
             clockTimeBool = true;
         }
 
-        String noArrivals = "There are no upcoming arrivals at your stop for the next " + arrivalScanMins + " minutes.";
+        String noArrivals = "There are no upcoming arrivals at your stop for the next " + arrivalScanMins + " minutes";
 
         if (arrivals.length == 0) {
             output = noArrivals;
@@ -99,7 +99,7 @@ public class SpeechUtil {
             output = UIUtils.getArrivalInfoSummary(arrivalInfo, SEPARATOR, clockTimeBool, timeZone, routesToFilter);
             if (TextUtils.isEmpty(output)) {
                 // If all currently running routes were filtered out, provide no arrivals message
-                output = noArrivals;
+                output = noArrivals + ", although arrivals for some routes are currently filtered out.";
             }
             log.info("ArrivalInfo: " + output);
         }

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -119,7 +119,7 @@ public class SpeechUtil {
         HashMap<String, HashSet<String>> routeFilters;
         Optional<ObaUserDataItem> optUserData = obaDao.getUserData(session);
         if (optUserData.isPresent()) {
-            routeFilters = optUserData.get().getRoutesToFilter();
+            routeFilters = optUserData.get().getRoutesToFilterOut();
             if (routeFilters != null) {
                 String stopId = (String) session.getAttribute(STOP_ID);
                 if (stopId == null) {

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -16,16 +16,19 @@
  */
 package org.onebusaway.alexa.util;
 
+import com.amazon.speech.speechlet.Session;
 import com.amazon.speech.speechlet.SpeechletResponse;
 import com.amazon.speech.ui.PlainTextOutputSpeech;
 import lombok.extern.log4j.Log4j;
+import org.onebusaway.alexa.storage.ObaDao;
+import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
 import org.onebusaway.io.client.util.ArrivalInfo;
 import org.onebusaway.io.client.util.UIUtils;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.TimeZone;
+import java.util.*;
+
+import static org.onebusaway.alexa.SessionAttribute.STOP_ID;
 
 /**
  * Utilities for speech-related actions
@@ -60,6 +63,27 @@ public class SpeechUtil {
             log.info("ArrivalInfo: " + output);
         }
         return output;
+    }
+
+    /**
+     * Returns the set of routes to filter for the given user and stop ID saved to the provided session, or null if
+     * there is no filter for the given STOP_ID
+     *
+     * @param obaDao
+     * @param session containing STOP_ID
+     * @return the set of routes to filter for the provided STOP_ID in the session for this user, or null if there is no
+     * filter for the given STOP_ID
+     */
+    public static HashSet getRoutesToFilter(ObaDao obaDao, Session session) {
+        HashMap<String, HashSet<String>> routeFilters;
+        Optional<ObaUserDataItem> optUserData = obaDao.getUserData(session);
+        if (optUserData.isPresent()) {
+            routeFilters = optUserData.get().getRoutesToFilter();
+            if (routeFilters != null) {
+                return routeFilters.get((String) session.getAttribute(STOP_ID));
+            }
+        }
+        return null;
     }
 
     public static SpeechletResponse getGeneralErrorMessage() {

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -21,6 +21,7 @@ import com.amazon.speech.speechlet.SpeechletResponse;
 import com.amazon.speech.ui.PlainTextOutputSpeech;
 import com.amazon.speech.ui.Reprompt;
 import lombok.extern.log4j.Log4j;
+import org.apache.http.util.TextUtils;
 import org.onebusaway.alexa.SessionAttribute;
 import org.onebusaway.alexa.storage.ObaDao;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
@@ -87,14 +88,19 @@ public class SpeechUtil {
             clockTimeBool = true;
         }
 
+        String noArrivals = "There are no upcoming arrivals at your stop for the next " + arrivalScanMins + " minutes.";
+
         if (arrivals.length == 0) {
-            output = "There are no upcoming arrivals at your stop for the next "
-                    + arrivalScanMins + " minutes.";
+            output = noArrivals;
         } else {
             List<ArrivalInfo> arrivalInfo = ArrivalInfo.convertObaArrivalInfo(arrivals, null,
                     currentTime, false, clockTimeBool, timeZone);
             final String SEPARATOR = " -- "; // with pause between sentences
             output = UIUtils.getArrivalInfoSummary(arrivalInfo, SEPARATOR, clockTimeBool, timeZone, routesToFilter);
+            if (TextUtils.isEmpty(output)) {
+                // If all routes currently running routes were filtered out, use no arrivals messsage
+                output = noArrivals;
+            }
             log.info("ArrivalInfo: " + output);
         }
         return output;

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -101,13 +101,13 @@ public class SpeechUtil {
     }
 
     /**
-     * Returns the set of routes to filter for the given user and stop ID saved to the provided session, or null if
-     * there is no filter for the given STOP_ID
+     * Returns the set of routes to filter for the given user and stop ID saved to the provided session or DAO
+     * (in that order), or null if there is no filter for the given STOP_ID
      *
      * @param obaDao
      * @param session containing STOP_ID
-     * @return the set of routes to filter for the provided STOP_ID in the session for this user, or null if there is no
-     * filter for the given STOP_ID
+     * @return the set of routes to filter for the provided STOP_ID in the session or DAO for this user, or null if
+     * there is no filter for the given STOP_ID
      */
     public static HashSet getRoutesToFilter(ObaDao obaDao, Session session) {
         HashMap<String, HashSet<String>> routeFilters;
@@ -115,7 +115,12 @@ public class SpeechUtil {
         if (optUserData.isPresent()) {
             routeFilters = optUserData.get().getRoutesToFilter();
             if (routeFilters != null) {
-                return routeFilters.get((String) session.getAttribute(STOP_ID));
+                String stopId = (String) session.getAttribute(STOP_ID);
+                if (stopId == null) {
+                    // Try to get Stop ID from DAO
+                    optUserData.get().getStopId();
+                }
+                return routeFilters.get(stopId);
             }
         }
         return null;

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Sean J. Barbeau (sjbarbeau@gmail.com),
+ * Copyright 2016-2017 Sean J. Barbeau (sjbarbeau@gmail.com),
  * Philip M. White (philip@mailworks.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,9 @@ package org.onebusaway.alexa.util;
 import com.amazon.speech.speechlet.Session;
 import com.amazon.speech.speechlet.SpeechletResponse;
 import com.amazon.speech.ui.PlainTextOutputSpeech;
+import com.amazon.speech.ui.Reprompt;
 import lombok.extern.log4j.Log4j;
+import org.onebusaway.alexa.SessionAttribute;
 import org.onebusaway.alexa.storage.ObaDao;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
@@ -28,6 +30,7 @@ import org.onebusaway.io.client.util.UIUtils;
 
 import java.util.*;
 
+import static org.onebusaway.alexa.SessionAttribute.ASK_STATE;
 import static org.onebusaway.alexa.SessionAttribute.STOP_ID;
 
 /**
@@ -35,6 +38,39 @@ import static org.onebusaway.alexa.SessionAttribute.STOP_ID;
  */
 @Log4j
 public class SpeechUtil {
+
+    private final static Reprompt cityReprompt;
+    private final static Reprompt stopNumReprompt;
+
+    static {
+        PlainTextOutputSpeech citySpeech = new PlainTextOutputSpeech();
+        citySpeech.setText("What is your city?");
+        cityReprompt = new Reprompt();
+        cityReprompt.setOutputSpeech(citySpeech);
+
+        PlainTextOutputSpeech stopNumSpeech = new PlainTextOutputSpeech();
+        stopNumSpeech.setText("What is your stop number?  You can find your stop's number on the placard in the bus zone, or in your OneBusAway app.");
+        stopNumReprompt = new Reprompt();
+        stopNumReprompt.setOutputSpeech(stopNumSpeech);
+    }
+
+    /**
+     * Returns the reprompt for setting a city
+     *
+     * @return the reprompt for setting a city
+     */
+    public static Reprompt getCityReprompt() {
+        return cityReprompt;
+    }
+
+    /**
+     * Returns the reprompt for setting a stop number
+     *
+     * @return
+     */
+    public static Reprompt getStopNumReprompt() {
+        return stopNumReprompt;
+    }
 
     /**
      * Format the arrival info for speach
@@ -84,6 +120,33 @@ public class SpeechUtil {
             }
         }
         return null;
+    }
+
+    /**
+     * Return the current AskState from the current session
+     *
+     * @param session
+     * @return the current AskState from the current session
+     */
+    public static SessionAttribute.AskState getAskState(Session session) {
+        SessionAttribute.AskState askState = SessionAttribute.AskState.NONE;
+        String savedAskState = (String) session.getAttribute(ASK_STATE);
+        if (savedAskState != null) {
+            askState = SessionAttribute.AskState.valueOf(savedAskState);
+        }
+        return askState;
+    }
+
+    /**
+     * Returns the goodbye response
+     *
+     * @return the goodbye response
+     */
+    public static SpeechletResponse goodbye() {
+        String output = String.format("Good-bye");
+        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+        out.setText(output);
+        return SpeechletResponse.newTellResponse(out);
     }
 
     public static SpeechletResponse getGeneralErrorMessage() {

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -16,11 +16,14 @@
  */
 package org.onebusaway.alexa.util;
 
+import com.amazon.speech.speechlet.SpeechletResponse;
+import com.amazon.speech.ui.PlainTextOutputSpeech;
 import lombok.extern.log4j.Log4j;
 import org.onebusaway.io.client.elements.ObaArrivalInfo;
 import org.onebusaway.io.client.util.ArrivalInfo;
 import org.onebusaway.io.client.util.UIUtils;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -35,9 +38,10 @@ public class SpeechUtil {
      * @param arrivals arrival information
      * @param arrivalScanMins number of minutes ahead that the arrival information was requested for
      * @param currentTime the time when this arrival information was generated
+     * @param routesToFilter a set of routeIds for routes that should NOT be read to the user
      * @return the arrival info text formatted for speech
      */
-    public static String getArrivalText(ObaArrivalInfo[] arrivals, int arrivalScanMins, long currentTime, long clockTime, TimeZone timeZone) {
+    public static String getArrivalText(ObaArrivalInfo[] arrivals, int arrivalScanMins, long currentTime, long clockTime, TimeZone timeZone, HashSet<String> routesToFilter) {
         String output;
 
         boolean clockTimeBool = false;
@@ -52,9 +56,24 @@ public class SpeechUtil {
             List<ArrivalInfo> arrivalInfo = ArrivalInfo.convertObaArrivalInfo(arrivals, null,
                     currentTime, false, clockTimeBool, timeZone);
             final String SEPARATOR = " -- "; // with pause between sentences
-            output = UIUtils.getArrivalInfoSummary(arrivalInfo, SEPARATOR, clockTimeBool, timeZone, null);
+            output = UIUtils.getArrivalInfoSummary(arrivalInfo, SEPARATOR, clockTimeBool, timeZone, routesToFilter);
             log.info("ArrivalInfo: " + output);
         }
         return output;
+    }
+
+    public static SpeechletResponse getGeneralErrorMessage() {
+        String output = String.format("Sorry, something went wrong.  Please try it again and it might work.");
+        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+        out.setText(output);
+        return SpeechletResponse.newTellResponse(out);
+    }
+
+    public static SpeechletResponse getCommunicationErrorMessage() {
+        String output = String.format("Sorry, something went wrong communicating with your region's OneBusAway server.  " +
+                "Please try it again and it might work.");
+        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+        out.setText(output);
+        return SpeechletResponse.newTellResponse(out);
     }
 }

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -30,8 +30,7 @@ import org.onebusaway.io.client.util.UIUtils;
 
 import java.util.*;
 
-import static org.onebusaway.alexa.SessionAttribute.ASK_STATE;
-import static org.onebusaway.alexa.SessionAttribute.STOP_ID;
+import static org.onebusaway.alexa.SessionAttribute.*;
 
 /**
  * Utilities for speech-related actions
@@ -135,6 +134,41 @@ public class SpeechUtil {
             askState = SessionAttribute.AskState.valueOf(savedAskState);
         }
         return askState;
+    }
+
+    /**
+     * Populates the provided session with persisted user data, if the session attribute is empty
+     *
+     * @param session
+     */
+    public static void populateAttributes(Session session, ObaUserDataItem userData) {
+        if (session.getAttribute(CITY_NAME) == null) {
+            session.setAttribute(CITY_NAME, userData.getCity());
+        }
+        if (session.getAttribute(STOP_ID) == null) {
+            session.setAttribute(STOP_ID, userData.getStopId());
+        }
+        if (session.getAttribute(REGION_ID) == null) {
+            session.setAttribute(REGION_ID, userData.getRegionId());
+        }
+        if (session.getAttribute(REGION_NAME) == null) {
+            session.setAttribute(REGION_NAME, userData.getRegionName());
+        }
+        if (session.getAttribute(OBA_BASE_URL) == null) {
+            session.setAttribute(OBA_BASE_URL, userData.getObaBaseUrl());
+        }
+        if (session.getAttribute(PREVIOUS_RESPONSE) == null) {
+            session.setAttribute(PREVIOUS_RESPONSE, userData.getPreviousResponse());
+        }
+        if (session.getAttribute(LAST_ACCESS_TIME) == null) {
+            session.setAttribute(LAST_ACCESS_TIME, userData.getLastAccessTime());
+        }
+        if (session.getAttribute(CLOCK_TIME) == null) {
+            session.setAttribute(CLOCK_TIME, userData.getSpeakClockTime());
+        }
+        if (session.getAttribute(TIME_ZONE) == null) {
+            session.setAttribute(TIME_ZONE, userData.getTimeZone());
+        }
     }
 
     /**

--- a/src/test/java/config/UnitTests.java
+++ b/src/test/java/config/UnitTests.java
@@ -27,6 +27,8 @@ import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
+
 @Configuration
 public class UnitTests {
     @Bean
@@ -60,7 +62,7 @@ public class UnitTests {
 
     @Bean
     public ObaUserDataItem testUserData() {
-        return new ObaUserDataItem("test-user-id", "Seattle", "test-stop-id", 1, "Puget Sound", "http://api.pugetsound.onebusaway.org/", "", System.currentTimeMillis(), 0, "America/Los_Angeles", null);
+        return new ObaUserDataItem("test-user-id", "Seattle", "test-stop-id", 1, "Puget Sound", "http://api.pugetsound.onebusaway.org/", "", System.currentTimeMillis(), 0, "America/Los_Angeles", new HashMap<>(), null);
     }
 
     @Bean

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -45,16 +45,12 @@ import util.TestUtil;
 import javax.annotation.Resource;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.onebusaway.alexa.ObaIntent.*;
 import static org.onebusaway.alexa.SessionAttribute.*;
 import static org.onebusaway.alexa.lib.ObaUserClient.ARRIVALS_SCAN_MINS;
@@ -595,12 +591,13 @@ public class AuthedSpeechletTest {
     }
 
     @Test
-    public void setRouteFilter() throws SpeechletException, IOException {
+    public void setRouteFilterNoYes() throws SpeechletException, IOException {
         String stopId = "6497";
+        String stopCode = stopId;
 
         // Route 1
-        String routeId = "Hillsborough Area Regional Transit_5";
-        String routeShortName = "5";
+        String routeId = "Hillsborough Area Regional Transit_1";
+        String routeShortName = "1";
         String routeLongName = "40th Street";
 
         // Route 2
@@ -623,12 +620,360 @@ public class AuthedSpeechletTest {
                 session
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
-        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopId + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
+        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopCode + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
 
-        // TODO - Test Yes and No responses, as well as the filter that gets written to DynamoDB.  Be sure to set session info like Alexa
-        // TODO - Add test for filtering routes for stop that has only 1 route
+        // Alexa does some data conversion for session variables - we need to imitate that here for routes
+        ArrayList<LinkedHashMap<String, String>> list = new ArrayList<>();
+        LinkedHashMap<String, String> route1Serialized = new LinkedHashMap<>();
+        route1Serialized.put("id", routeId);
+        route1Serialized.put("shortName", routeShortName);
+        route1Serialized.put("longName", routeLongName);
+        list.add(route1Serialized);
+        LinkedHashMap<String, String> route2Serialized = new LinkedHashMap<>();
+        route2Serialized.put("id", routeId2);
+        route2Serialized.put("shortName", routeShortName2);
+        route2Serialized.put("longName", routeLongName2);
+        list.add(route2Serialized);
+        session.setAttribute(DIALOG_ROUTES_TO_ASK_ABOUT, list);
+
+        // First say the Yes intent
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(YES)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Ok, how about Route " + routeShortName2 + "?"));
+
+        // Then say YES again
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(YES)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Alright, I've saved your route filter for stop " + stopCode + "."));
+
+        // Test to make sure that both routes are being filtered out
+        HashMap<String, HashSet<String>> routeFilters = testUserData.getRoutesToFilterOut();
+        HashSet<String> routesToFilterHashSet = routeFilters.get(stopId);
+        assertFalse(routesToFilterHashSet.contains(routeId));
+        assertFalse(routesToFilterHashSet.contains(routeId2));
     }
 
+    @Test
+    public void setRouteFilterYesNo() throws SpeechletException, IOException {
+        String stopId = "6497";
+        String stopCode = stopId;
+
+        // Route 1
+        String routeId = "Hillsborough Area Regional Transit_1";
+        String routeShortName = "1";
+        String routeLongName = "40th Street";
+
+        // Route 2
+        String routeId2 = "Hillsborough Area Regional Transit_2";
+        String routeShortName2 = "2";
+        String routeLongName2 = "Nebraska Avenue";
+
+        setupRouteFilter(stopId, routeId, routeShortName, routeLongName, routeId2, routeShortName2, routeLongName2);
+
+        // Ask to set the route filter
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(SET_ROUTE_FILTER)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopCode + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
+
+
+        // Alexa does some data conversion for session variables - we need to imitate that here for routes
+        ArrayList<LinkedHashMap<String, String>> list = new ArrayList<>();
+        LinkedHashMap<String, String> route1Serialized = new LinkedHashMap<>();
+        route1Serialized.put("id", routeId);
+        route1Serialized.put("shortName", routeShortName);
+        route1Serialized.put("longName", routeLongName);
+        list.add(route1Serialized);
+        LinkedHashMap<String, String> route2Serialized = new LinkedHashMap<>();
+        route2Serialized.put("id", routeId2);
+        route2Serialized.put("shortName", routeShortName2);
+        route2Serialized.put("longName", routeLongName2);
+        list.add(route2Serialized);
+        session.setAttribute(DIALOG_ROUTES_TO_ASK_ABOUT, list);
+
+        // Say YES
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(YES)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Ok, how about Route " + routeShortName2 + "?"));
+
+        // Say NO
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(NO)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Alright, I've saved your route filter for stop " + stopCode + "."));
+
+        // Test to make sure that both routes are being filtered out
+        HashMap<String, HashSet<String>> routeFilters = testUserData.getRoutesToFilterOut();
+        HashSet<String> routesToFilterHashSet = routeFilters.get(stopId);
+        assertFalse(routesToFilterHashSet.contains(routeId));
+        assertTrue(routesToFilterHashSet.contains(routeId2));
+    }
+
+    @Test
+    public void setRouteFilterYesYes() throws SpeechletException, IOException {
+        String stopId = "6497";
+        String stopCode = stopId;
+
+        // Route 1
+        String routeId = "Hillsborough Area Regional Transit_1";
+        String routeShortName = "1";
+        String routeLongName = "40th Street";
+
+        // Route 2
+        String routeId2 = "Hillsborough Area Regional Transit_2";
+        String routeShortName2 = "2";
+        String routeLongName2 = "Nebraska Avenue";
+
+        setupRouteFilter(stopId, routeId, routeShortName, routeLongName, routeId2, routeShortName2, routeLongName2);
+
+        // Ask to set the route filter
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(SET_ROUTE_FILTER)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopCode + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
+
+        // Alexa does some data conversion for session variables - we need to imitate that here for routes
+        ArrayList<LinkedHashMap<String, String>> list = new ArrayList<>();
+        LinkedHashMap<String, String> route1Serialized = new LinkedHashMap<>();
+        route1Serialized.put("id", routeId);
+        route1Serialized.put("shortName", routeShortName);
+        route1Serialized.put("longName", routeLongName);
+        list.add(route1Serialized);
+        LinkedHashMap<String, String> route2Serialized = new LinkedHashMap<>();
+        route2Serialized.put("id", routeId2);
+        route2Serialized.put("shortName", routeShortName2);
+        route2Serialized.put("longName", routeLongName2);
+        list.add(route2Serialized);
+        session.setAttribute(DIALOG_ROUTES_TO_ASK_ABOUT, list);
+
+        // First say the No intent
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(NO)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Ok, how about Route " + routeShortName2 + "?"));
+
+        // Say YES
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(YES)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Alright, I've saved your route filter for stop " + stopCode + "."));
+
+        // Test to make sure that both routes are being filtered out
+        HashMap<String, HashSet<String>> routeFilters = testUserData.getRoutesToFilterOut();
+        HashSet<String> routesToFilterHashSet = routeFilters.get(stopId);
+        assertTrue(routesToFilterHashSet.contains(routeId));
+        assertFalse(routesToFilterHashSet.contains(routeId2));
+    }
+
+    @Test
+    public void setRouteFilterNoNo() throws SpeechletException, IOException {
+        String stopId = "6497";
+        String stopCode = stopId;
+
+        // Route 1
+        String routeId = "Hillsborough Area Regional Transit_1";
+        String routeShortName = "1";
+        String routeLongName = "40th Street";
+
+        // Route 2
+        String routeId2 = "Hillsborough Area Regional Transit_2";
+        String routeShortName2 = "2";
+        String routeLongName2 = "Nebraska Avenue";
+
+        setupRouteFilter(stopId, routeId, routeShortName, routeLongName, routeId2, routeShortName2, routeLongName2);
+
+        // Ask to set the route filter
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(SET_ROUTE_FILTER)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopCode + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
+
+
+        // Alexa does some data conversion for session variables - we need to imitate that here for routes
+        ArrayList<LinkedHashMap<String, String>> list = new ArrayList<>();
+        LinkedHashMap<String, String> route1Serialized = new LinkedHashMap<>();
+        route1Serialized.put("id", routeId);
+        route1Serialized.put("shortName", routeShortName);
+        route1Serialized.put("longName", routeLongName);
+        list.add(route1Serialized);
+        LinkedHashMap<String, String> route2Serialized = new LinkedHashMap<>();
+        route2Serialized.put("id", routeId2);
+        route2Serialized.put("shortName", routeShortName2);
+        route2Serialized.put("longName", routeLongName2);
+        list.add(route2Serialized);
+        session.setAttribute(DIALOG_ROUTES_TO_ASK_ABOUT, list);
+
+        // Say No
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(NO)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Ok, how about Route " + routeShortName2 + "?"));
+
+        // Say No
+        sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(NO)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+
+        spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Alright, I've saved your route filter for stop " + stopCode + "."));
+
+        // Test to make sure that both routes are being filtered out
+        HashMap<String, HashSet<String>> routeFilters = testUserData.getRoutesToFilterOut();
+        HashSet<String> routesToFilterHashSet = routeFilters.get(stopId);
+        assertTrue(routesToFilterHashSet.contains(routeId));
+        assertTrue(routesToFilterHashSet.contains(routeId2));
+    }
+
+    @Test
+    public void setRouteFilterOnlyOneRoute() throws SpeechletException, IOException {
+        String stopId = "6497";
+        String stopCode = stopId;
+
+        // Route 1
+        String routeId = "Hillsborough Area Regional Transit_1";
+        String routeShortName = "1";
+        String routeLongName = "40th Street";
+
+        // Route 2 - set to null so it's not added to route list (we only want one route in list)
+        setupRouteFilter(stopId, routeId, routeShortName, routeLongName, null, null, null);
+
+        // Ask to set the route filter
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(SET_ROUTE_FILTER)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("There is only one route for stop " + stopCode + ", so I can't filter out any routes."));
+    }
+
+    /**
+     * Properites to set up a route filter with.  If routeId2 properties are null, then only one route is added for the
+     * stop, otherwise 2 routes are added for the stop.
+     *
+     * @param stopId
+     * @param routeId
+     * @param routeShortName
+     * @param routeLongName
+     * @param routeId2
+     * @param routeShortName2
+     * @param routeLongName2
+     * @throws IOException
+     */
     private void setupRouteFilter(String stopId, String routeId, String routeShortName, String routeLongName, String routeId2, String routeShortName2, String routeLongName2) throws IOException {
         // Mock persisted user data
         testUserData.setUserId(TEST_USER_ID);
@@ -638,10 +983,17 @@ public class AuthedSpeechletTest {
         testUserData.setRegionId(TEST_REGION_1.getId());
         testUserData.setObaBaseUrl(TEST_REGION_1.getObaBaseUrl());
 
+        ObaRoute[] obaRouteArray;
+
         // Mock route info
-        ObaRoute[] obaRouteArray = new ObaRoute[2];
-        obaRouteArray[0] = obaRoute;
-        obaRouteArray[1] = obaRoute2;
+        if (routeId2 != null) {
+            obaRouteArray = new ObaRoute[2];
+            obaRouteArray[0] = obaRoute;
+            obaRouteArray[1] = obaRoute2;
+        } else {
+            obaRouteArray = new ObaRoute[1];
+            obaRouteArray[0] = obaRoute;
+        }
 
         new NonStrictExpectations() {{
             obaRoute.getId();

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -192,8 +192,8 @@ public class AuthedSpeechletTest {
     @Test
     public void launchTellsArrivalsFilteredAllRoutes() throws SpeechletException, IOException {
         HashMap<String, HashSet<String>> routeFilters = new HashMap<>();
-        String stopId = "Hillsoborough Area Regional Transit_100";
-        String routeId = "Hillsoborough Area Regional Transit_8";
+        String stopId = "Hillsborough Area Regional Transit_100";
+        String routeId = "Hillsborough Area Regional Transit_8";
         HashSet<String> routesToFilter = new HashSet<>();
         routesToFilter.add(routeId);
         routeFilters.put(stopId, routesToFilter);

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -219,8 +219,8 @@ public class AuthedSpeechletTest {
         }};
 
         HashMap<String, Slot> slots = new HashMap<>();
-        slots.put(STOP_NUMBER, Slot.builder()
-                .withName(STOP_NUMBER)
+        slots.put(STOP_ID, Slot.builder()
+                .withName(STOP_ID)
                 .withValue(newStopCode).build());
         SpeechletResponse sr = authedSpeechlet.onIntent(
                 IntentRequest.builder()
@@ -449,7 +449,7 @@ public class AuthedSpeechletTest {
         obaStop2Serialized.put("stopCode", newStopCode);
         obaStop2Serialized.put("name", stopName2);
         list.add(obaStop2Serialized);
-        session.setAttribute(FOUND_STOPS, list);
+        session.setAttribute(DIALOG_FOUND_STOPS, list);
 
         // Now say the YES intent
         sr = authedSpeechlet.onIntent(
@@ -496,7 +496,7 @@ public class AuthedSpeechletTest {
         obaStop2Serialized.put("stopCode", newStopCode);
         obaStop2Serialized.put("name", stopName2);
         list.add(obaStop2Serialized);
-        session.setAttribute(FOUND_STOPS, list);
+        session.setAttribute(DIALOG_FOUND_STOPS, list);
 
         // Now say the NO intent
         sr = authedSpeechlet.onIntent(
@@ -555,8 +555,8 @@ public class AuthedSpeechletTest {
         }};
 
         HashMap<String, Slot> slots = new HashMap<>();
-        slots.put(STOP_NUMBER, Slot.builder()
-                .withName(STOP_NUMBER)
+        slots.put(STOP_ID, Slot.builder()
+                .withName(STOP_ID)
                 .withValue(stopCode).build());
         SpeechletResponse sr = authedSpeechlet.onIntent(
                 IntentRequest.builder()
@@ -585,7 +585,7 @@ public class AuthedSpeechletTest {
         obaStop2Serialized.put("name", stopName2);
         list.add(obaStopSerialized);
         list.add(obaStop2Serialized);
-        session.setAttribute(FOUND_STOPS, list);
+        session.setAttribute(DIALOG_FOUND_STOPS, list);
     }
 
     @Test

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -660,6 +660,7 @@ public class AuthedSpeechletTest {
         assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopId));
 
         // TODO - Test Yes and No responses, as well as the filter that gets written to DynamoDB.  Be sure to set session info like Alexa
+        // TODO - Add test for filtering routes for stop that has only 1 route
     }
 
     @Test

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -657,7 +657,7 @@ public class AuthedSpeechletTest {
                 session
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
-        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopId));
+        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopId + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
 
         // TODO - Test Yes and No responses, as well as the filter that gets written to DynamoDB.  Be sure to set session info like Alexa
         // TODO - Add test for filtering routes for stop that has only 1 route

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -608,6 +608,28 @@ public class AuthedSpeechletTest {
         String routeShortName2 = "2";
         String routeLongName2 = "Nebraska Avenue";
 
+        setupRouteFilter(stopId, routeId, routeShortName, routeLongName, routeId2, routeShortName2, routeLongName2);
+
+        // Ask to set the route filter
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id2")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(SET_ROUTE_FILTER)
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopId + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
+
+        // TODO - Test Yes and No responses, as well as the filter that gets written to DynamoDB.  Be sure to set session info like Alexa
+        // TODO - Add test for filtering routes for stop that has only 1 route
+    }
+
+    private void setupRouteFilter(String stopId, String routeId, String routeShortName, String routeLongName, String routeId2, String routeShortName2, String routeLongName2) throws IOException {
         // Mock persisted user data
         testUserData.setUserId(TEST_USER_ID);
         testUserData.setStopId(stopId);
@@ -643,24 +665,6 @@ public class AuthedSpeechletTest {
             obaUserClient.getStop(anyString);
             result = obaStopResponse;
         }};
-
-        // Ask to set the route filter
-        SpeechletResponse sr = authedSpeechlet.onIntent(
-                IntentRequest.builder()
-                        .withRequestId("test-request-id2")
-                        .withIntent(
-                                Intent.builder()
-                                        .withName(SET_ROUTE_FILTER)
-                                        .build()
-                        )
-                        .build(),
-                session
-        );
-        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
-        assertThat(spoken, startsWith("Sure, let's set up a route filter for stop " + stopId + ".  Do you want to hear arrivals for Route " + routeShortName + "?"));
-
-        // TODO - Test Yes and No responses, as well as the filter that gets written to DynamoDB.  Be sure to set session info like Alexa
-        // TODO - Add test for filtering routes for stop that has only 1 route
     }
 
     @Test

--- a/src/test/java/org/onebusaway/alexa/MainSpeechletEmptyTest.java
+++ b/src/test/java/org/onebusaway/alexa/MainSpeechletEmptyTest.java
@@ -282,8 +282,8 @@ public class MainSpeechletEmptyTest {
     @Test
     public void setStopWithoutStopNumber() throws SpeechletException {
         HashMap<String, Slot> slots = new HashMap<>();
-        slots.put(STOP_NUMBER, Slot.builder()
-                .withName(STOP_NUMBER)
+        slots.put(STOP_ID, Slot.builder()
+                .withName(STOP_ID)
                 .withValue(null).build());
         SpeechletResponse sr = mainSpeechlet.onIntent(
                 IntentRequest.builder()
@@ -326,8 +326,8 @@ public class MainSpeechletEmptyTest {
         }};
 
         HashMap<String, Slot> slots = new HashMap<>();
-        slots.put(STOP_NUMBER, Slot.builder()
-                .withName(STOP_NUMBER)
+        slots.put(STOP_ID, Slot.builder()
+                .withName(STOP_ID)
                 .withValue(newStopCode).build());
         SpeechletResponse sr = mainSpeechlet.onIntent(
                 IntentRequest.builder()
@@ -344,7 +344,7 @@ public class MainSpeechletEmptyTest {
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, equalTo("You haven't set your region yet. In what city is stop " + newStopCode + "?"));
         assertThat(session.getAttribute(ASK_STATE), equalTo(AskState.STOP_BEFORE_CITY.toString()));
-        assertThat(session.getAttribute(STOP_NUMBER), equalTo(newStopCode));
+        assertThat(session.getAttribute(STOP_ID), equalTo(newStopCode));
 
         HashMap<String, Slot> citySlots = new HashMap<>();
         citySlots.put(CITY_NAME, Slot.builder()
@@ -384,7 +384,7 @@ public class MainSpeechletEmptyTest {
 
         //Session attributes from initial SET_STOP_NUMBER call
         session.setAttribute(ASK_STATE, AskState.STOP_BEFORE_CITY.toString());
-        session.setAttribute(STOP_NUMBER, newStopCode);
+        session.setAttribute(STOP_ID, newStopCode);
 
         HashMap<String, Slot> citySlots = new HashMap<>();
         citySlots.put(CITY_NAME, Slot.builder()

--- a/src/test/java/org/onebusaway/alexa/SpeechUtilTest.java
+++ b/src/test/java/org/onebusaway/alexa/SpeechUtilTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Sean J. Barbeau (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.alexa;
+
+import com.amazon.speech.speechlet.Session;
+import com.amazon.speech.speechlet.SpeechletException;
+import com.amazon.speech.speechlet.User;
+import config.UnitTests;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.onebusaway.alexa.storage.ObaUserDataItem;
+import org.onebusaway.alexa.util.SpeechUtil;
+import org.onebusaway.io.client.elements.ObaRegion;
+import org.onebusaway.io.client.elements.ObaRegionElement;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import javax.annotation.Resource;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.onebusaway.alexa.SessionAttribute.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class,
+        classes = UnitTests.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class SpeechUtilTest {
+    static final String TEST_USER_ID = "test-user-id";
+    static final User testUser = User.builder().withUserId(TEST_USER_ID).build();
+    Session session;
+
+    private static final ObaRegion TEST_REGION = new ObaRegionElement(
+            2,
+            "Puget Sound",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, true, true,
+            "test-twitter",
+            false,
+            "test-stop-info-url"
+    );
+
+    @Resource
+    AuthedSpeechlet authedSpeechlet;
+
+    @Resource
+    ObaUserDataItem testUserData;
+
+    @Before
+    public void initializeAuthedSpeechlet() throws URISyntaxException {
+        authedSpeechlet.setUserData(testUserData);
+    }
+
+    @Before
+    public void resetFactoryObjects() {
+        session = Session.builder().withUser(testUser).withSessionId("test-session-id").build();
+    }
+
+    @Test
+    public void populateSession() throws SpeechletException {
+        // Mock persisted user data
+        ObaUserDataItem userData = new ObaUserDataItem(
+                TEST_USER_ID,
+                "Puget Sound",
+                "6497",
+                TEST_REGION.getId(),
+                TEST_REGION.getName(),
+                TEST_REGION.getObaBaseUrl(),
+                "",
+                System.currentTimeMillis(),
+                0,
+                "America/Los_Angeles",
+                new HashMap<>(),
+                null
+        );
+
+        Session emptySession = Session.builder()
+                .withUser(testUser)
+                .withSessionId("test-session-id")
+                .build();
+
+        SpeechUtil.populateAttributes(emptySession, userData);
+
+        assertEquals(userData.getRegionName(), emptySession.getAttribute(CITY_NAME));
+        assertEquals(userData.getStopId(), emptySession.getAttribute(STOP_ID));
+        assertEquals(userData.getRegionId(), emptySession.getAttribute(REGION_ID));
+        assertEquals(userData.getRegionName(), emptySession.getAttribute(REGION_NAME));
+        assertEquals(userData.getObaBaseUrl(), emptySession.getAttribute(OBA_BASE_URL));
+        assertEquals(userData.getPreviousResponse(), emptySession.getAttribute(PREVIOUS_RESPONSE));
+        assertEquals(userData.getLastAccessTime(), emptySession.getAttribute(LAST_ACCESS_TIME));
+        assertEquals(userData.getSpeakClockTime(), emptySession.getAttribute(CLOCK_TIME));
+        assertEquals(userData.getTimeZone(), emptySession.getAttribute(TIME_ZONE));
+    }
+}

--- a/src/test/java/util/TestUtil.java
+++ b/src/test/java/util/TestUtil.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.onebusaway.alexa.ObaIntent.STOP;
 import static org.onebusaway.alexa.SessionAttribute.CITY_NAME;
-import static org.onebusaway.alexa.SessionAttribute.STOP_NUMBER;
+import static org.onebusaway.alexa.SessionAttribute.STOP_ID;
 
 /**
  * Utilities to assist in testing the OBA Alexa skill
@@ -54,8 +54,8 @@ public class TestUtil {
         slots.put(CITY_NAME, Slot.builder()
                 .withName(CITY_NAME)
                 .withValue("Tampa").build());
-        slots.put(STOP_NUMBER, Slot.builder()
-                .withName(STOP_NUMBER)
+        slots.put(STOP_ID, Slot.builder()
+                .withName(STOP_ID)
                 .withValue("6497").build());
 
         // Loop through all intents using reflection to make sure we're handling them


### PR DESCRIPTION
TODO:
- [x] Persist the user's answer as to which routes they want to hear arrivals for, both within the session when setting the filter and finally to DynamoDB
- [x] Actually filter out the arrivals when reading predictions to user
- [x] Don't save HashMaps or HashSets to sessions (they get converted by Alexa to ArrayLists)
- [x] Fix issue with setting for stop with duplicate stop ID (it currently loops back to beginning of onboard (askForCity(Optional.empty()).
- [x] Fix issue with filter not being used after setting new stop ID in the immediately returned arrival info ("...Right now,...")
- [x] What happens if you ask for arrivals for a stop, and the only arrival for that stop gets filtered out?  Seems like it might be an empty string.  If so, we need to check for this and then say "there are no arrivals in the next X minutes."
- [x] Unit tests