### PR TITLE
Fix #92 - Support experimental regions as user setting

### DIFF
--- a/interaction model/schema.json
+++ b/interaction model/schema.json
@@ -59,6 +59,12 @@
     },
     {
       "intent": "SetRouteFilter"
+    },
+    {
+      "intent": "EnableExperimentalRegions"
+    },
+    {
+      "intent": "DisableExperimentalRegions"
     }
   ]
 }

--- a/interaction model/utterances.txt
+++ b/interaction model/utterances.txt
@@ -109,6 +109,24 @@ SetRouteFilter create my route filter
 SetRouteFilter filter routes
 SetRouteFilter filter out routes
 
+EnableExperimentalRegions enable experimental region
+EnableExperimentalRegions enable experimental regions
+EnableExperimentalRegions turn on experimental region
+EnableExperimentalRegions turn on experimental regions
+EnableExperimentalRegions enable beta region
+EnableExperimentalRegions enable beta regions
+EnableExperimentalRegions turn on beta region
+EnableExperimentalRegions turn on beta regions
+
+DisableExperimentalRegions disable experimental region
+DisableExperimentalRegions disable experimental regions
+DisableExperimentalRegions turn off experimental region
+DisableExperimentalRegions turn off experimental regions
+DisableExperimentalRegions disable beta region
+DisableExperimentalRegions disable beta regions
+DisableExperimentalRegions turn off beta region
+DisableExperimentalRegions turn off beta regions
+
 GetArrivalsIntent where is my {TransitMode}
 GetArrivalsIntent where's my {TransitMode}
 GetArrivalsIntent when is my {TransitMode}

--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -80,6 +80,8 @@ public class AnonSpeechlet implements Speechlet {
                 ENABLE_CLOCK_TIME.equals(intent.getName()) ||
                 DISABLE_CLOCK_TIME.equals(intent.getName()) ||
                 SET_ROUTE_FILTER.equals(intent.getName()) ||
+                DISABLE_EXPERIMENTAL_REGIONS.equals(intent.getName()) ||
+                ENABLE_EXPERIMENTAL_REGIONS.equals(intent.getName()) ||
                 REPEAT.equals(intent.getName())) {
             // User asked for help, or we don't yet have enough information to respond.  Return welcome message.
             return CityUtil.askForCity(Optional.empty(), obaClient, session);

--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -128,7 +128,7 @@ public class AnonSpeechlet implements Speechlet {
                 } else {
                     PlainTextOutputSpeech out = new PlainTextOutputSpeech();
                     out.setText(String.format("Ok, we found the %s region near you.  What's your stop number?",
-                            region.get().getName()));
+                            SpeechUtil.formatRegionName(region.get().getName())));
                     return SpeechletResponse.newAskResponse(out, SpeechUtil.getStopNumReprompt());
                 }
             }

--- a/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AnonSpeechlet.java
@@ -27,7 +27,6 @@ import org.onebusaway.alexa.storage.ObaDao;
 import org.onebusaway.alexa.util.*;
 import org.onebusaway.io.client.elements.ObaRegion;
 import org.onebusaway.io.client.elements.ObaStop;
-import org.onebusaway.io.client.util.RegionUtils;
 import org.onebusaway.location.Location;
 
 import javax.annotation.Resource;
@@ -216,7 +215,7 @@ public class AnonSpeechlet implements Speechlet {
             log.error("Error getting closest region: " + e.getMessage());
             return CityUtil.askForCity(Optional.of(cityName), obaClient, session);
         }
-        if (!region.isPresent() || !RegionUtils.isRegionUsable(region.get())) {
+        if (!region.isPresent()) {
             // Couldn't find a nearby region that supports the OBA REST API
             return CityUtil.askForCity(Optional.of(cityName), obaClient, session);
         }

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import static org.onebusaway.alexa.ObaIntent.*;
@@ -68,7 +69,7 @@ public class AuthedSpeechlet implements Speechlet {
     public SpeechletResponse onIntent(final IntentRequest request,
                                       final Session session)
             throws SpeechletException {
-        SessionUtil.populateAttributes(session, userData);
+        SessionUtil.populateAttributes(session, Optional.of(userData));
         AskState askState = SessionUtil.getAskState(session);
         session.setAttribute(ASK_STATE, AskState.NONE.toString());
 
@@ -110,7 +111,7 @@ public class AuthedSpeechlet implements Speechlet {
     public SpeechletResponse onLaunch(final LaunchRequest request,
                                       final Session session)
             throws SpeechletException {
-        SessionUtil.populateAttributes(session, userData);
+        SessionUtil.populateAttributes(session, Optional.of(userData));
         return tellArrivals(session);
     }
 

--- a/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
+++ b/src/main/java/org/onebusaway/alexa/AuthedSpeechlet.java
@@ -100,6 +100,10 @@ public class AuthedSpeechlet implements Speechlet {
             return disableClockTime(session);
         } else if (SET_ROUTE_FILTER.equals(intent.getName())) {
             return setRouteFilter(session);
+        } else if (ENABLE_EXPERIMENTAL_REGIONS.equals(intent.getName())) {
+            return enableExperimentalRegions(session);
+        } else if (DISABLE_EXPERIMENTAL_REGIONS.equals(intent.getName())) {
+            return disableExperimentalRegions(session);
         } else if (STOP.equals(intent.getName()) || CANCEL.equals(intent.getName())) {
             return SpeechUtil.goodbye();
         } else {
@@ -266,5 +270,14 @@ public class AuthedSpeechlet implements Speechlet {
 
         log.error("Received no intent without a question.");
         return SpeechUtil.getGeneralErrorMessage();
+    }
+
+    private SpeechletResponse enableExperimentalRegions(Session session) throws SpeechletException {
+        return StorageUtil.updateExperimentalRegions(true, session, obaDao, userData, obaUserClient);
+
+    }
+
+    private SpeechletResponse disableExperimentalRegions(Session session) throws SpeechletException {
+        return StorageUtil.updateExperimentalRegions(false, session, obaDao, userData, obaUserClient);
     }
 }

--- a/src/main/java/org/onebusaway/alexa/ObaIntent.java
+++ b/src/main/java/org/onebusaway/alexa/ObaIntent.java
@@ -28,6 +28,8 @@ public class ObaIntent {
     public static final String ENABLE_CLOCK_TIME = "EnableClockTime";
     public static final String DISABLE_CLOCK_TIME = "DisableClockTime";
     public static final String SET_ROUTE_FILTER = "SetRouteFilter";
+    public static final String ENABLE_EXPERIMENTAL_REGIONS = "EnableExperimentalRegions";
+    public static final String DISABLE_EXPERIMENTAL_REGIONS = "DisableExperimentalRegions";
     public static final String HELP = "AMAZON.HelpIntent";
     public static final String REPEAT = "AMAZON.RepeatIntent";
     public static final String STOP = "AMAZON.StopIntent";

--- a/src/main/java/org/onebusaway/alexa/SessionAttribute.java
+++ b/src/main/java/org/onebusaway/alexa/SessionAttribute.java
@@ -36,6 +36,7 @@ public class SessionAttribute {
     public static final String DIALOG_ROUTES_TO_FILTER = "dialogRoutesToFilter";
     public static final String ANNOUNCED_INTRODUCTION = "announcedIntroduction";
     public static final String ANNOUNCED_FEATURES_V1_1_0 = "announcedFeaturesv1_1_0";
+    public static final String EXPERIMENTAL_REGIONS = "experimentalRegions";
 
     // Strangely, we can't save HashSets or HashMaps to sessions (Amazon Alexa converts them to ArrayLists, which
     // generates a ClassCastException when trying to retrieve them.  This prevents us from saving route filters to sessions.

--- a/src/main/java/org/onebusaway/alexa/lib/ObaClientSharedCode.java
+++ b/src/main/java/org/onebusaway/alexa/lib/ObaClientSharedCode.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Log4j
 public abstract class ObaClientSharedCode {
@@ -42,26 +43,33 @@ public abstract class ObaClientSharedCode {
      * which we will then use to get stop and arrival data for that region.
      *
      * @param l geographic location used to search for nearby regions
+     * @param includeExperimentalRegions true if experimental (beta) regions should be included, false if they should not
      * @return the closest region in the Regions API to the given location, or null if there are no nearby regions
      * (within 100 miles of the provided location) or a region couldn't be found.
      */
-    public Optional<ObaRegion> getClosestRegion(@NonNull Location l) throws IOException {
+    public Optional<ObaRegion> getClosestRegion(@NonNull Location l, boolean includeExperimentalRegions) throws IOException {
         log.debug("Invoked getClosestRegion() with location " + l.toString());
         return Optional.ofNullable(RegionUtils.getClosestRegion(
-                getAllRegions(),
+                getAllRegions(includeExperimentalRegions),
                 l,
                 true)); // enforce proximity threshold
     }
 
     /**
      * Get all OBA regions from the Regions API ((http://regions.onebusaway.org/regions-v3.json))
+     * @param includeExperimentalRegions true if experimental (beta) regions should be included, false if they should not
      * @return all OBA regions
      * @throws SpeechletException
      */
-    public List<ObaRegion> getAllRegions() throws IOException {
+    public List<ObaRegion> getAllRegions(boolean includeExperimentalRegions) throws IOException {
         ObaRegionsResponse response = ObaRegionsRequest.newRequest().call();
         if (response.getCode() == ObaApi.OBA_OK) {
-            return Arrays.asList(response.getRegions());
+            List<ObaRegion> regions = Arrays.asList(response.getRegions());
+            return regions.stream()
+                    .filter(r -> RegionUtils.isRegionUsable(r)
+                            && (!r.getExperimental() || includeExperimentalRegions)
+                            && r.getObaBaseUrl() != null)
+                    .collect(Collectors.toList());
         } else {
             throw new IOException("Error getting regions");
         }

--- a/src/main/java/org/onebusaway/alexa/lib/ObaClientSharedCode.java
+++ b/src/main/java/org/onebusaway/alexa/lib/ObaClientSharedCode.java
@@ -54,7 +54,7 @@ public abstract class ObaClientSharedCode {
         return Optional.ofNullable(RegionUtils.getClosestRegion(
                 getAllRegions(includeExperimentalRegions),
                 l,
-                true)); // enforce proximity threshold
+                true, false)); // enforce proximity threshold
     }
 
     /**

--- a/src/main/java/org/onebusaway/alexa/lib/ObaClientSharedCode.java
+++ b/src/main/java/org/onebusaway/alexa/lib/ObaClientSharedCode.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.onebusaway.alexa.util.CityUtil.NEW_YORK_REGION_ID;
+
 @Log4j
 public abstract class ObaClientSharedCode {
 
@@ -66,7 +68,7 @@ public abstract class ObaClientSharedCode {
         if (response.getCode() == ObaApi.OBA_OK) {
             List<ObaRegion> regions = Arrays.asList(response.getRegions());
             return regions.stream()
-                    .filter(r -> RegionUtils.isRegionUsable(r)
+                    .filter(r -> (RegionUtils.isRegionUsable(r) || (r.getId() == NEW_YORK_REGION_ID && includeExperimentalRegions))
                             && (!r.getExperimental() || includeExperimentalRegions)
                             && r.getObaBaseUrl() != null)
                     .collect(Collectors.toList());

--- a/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
+++ b/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
@@ -126,6 +126,15 @@ public class ObaUserDataItem {
     @DynamoDBAttribute(attributeName = "AnnouncedFeatures-v1_1_0")
     private long announcedFeaturesv1_1_0;
 
+    /**
+     * Whether or not the user should hear information for experimental regions
+     * <p>
+     */
+    @Getter
+    @Setter
+    @DynamoDBAttribute(attributeName = "ExperimentalRegions")
+    private boolean experimentalRegions;
+
     @DynamoDBVersionAttribute
     private Long version;
 }

--- a/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
+++ b/src/main/java/org/onebusaway/alexa/storage/ObaUserDataItem.java
@@ -84,7 +84,7 @@ public class ObaUserDataItem {
     private long lastAccessTime;
 
     /**
-     * 0 for false, 1 for true (Apparently DynamoDB doesn't persist booleans)
+     * 0 for false, 1 for true (I thought DynamoDB didn't persist booleans at the time - FIXME?)
      */
     @Getter
     @Setter
@@ -109,7 +109,7 @@ public class ObaUserDataItem {
     /**
      * Whether or not we've given the user the introduction to OneBusAway when they first use the skill
      * <p>
-     * 0 for false, 1 for true (Apparently DynamoDB doesn't persist booleans)
+     * 0 for false, 1 for true (I thought DynamoDB didn't persist booleans at the time - FIXME?)
      */
     @Getter
     @Setter
@@ -119,7 +119,7 @@ public class ObaUserDataItem {
     /**
      * Whether or not we've given the user an update for what's new in v1.1.0
      * <p>
-     * 0 for false, 1 for true (Apparently DynamoDB doesn't persist booleans)
+     * 0 for false, 1 for true (I thought DynamoDB didn't persist booleans at the time - FIXME?)
      */
     @Getter
     @Setter

--- a/src/main/java/org/onebusaway/alexa/util/CityUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/CityUtil.java
@@ -37,6 +37,8 @@ import static org.onebusaway.alexa.SessionAttribute.*;
 @Log4j
 public class CityUtil {
 
+    public static long NEW_YORK_REGION_ID = 2;  // From http://regions.onebusaway.org/regions-v3.json
+
     /**
      * Returns the response required to start the initial dialog with the user to select their city/region
      *
@@ -82,7 +84,7 @@ public class CityUtil {
     public static String allRegionsSpoken(List<ObaRegion> regions, boolean includeExperimentalRegions) {
         List<String> activeRegions = regions
                 .stream()
-                .filter(r -> RegionUtils.isRegionUsable(r)
+                .filter(r -> (RegionUtils.isRegionUsable(r) || (r.getId() == NEW_YORK_REGION_ID && includeExperimentalRegions))
                         && (!r.getExperimental() || includeExperimentalRegions)
                         && r.getObaBaseUrl() != null)
                 .map(r -> String.format("%s, ", SpeechUtil.formatRegionName(r.getName())))

--- a/src/main/java/org/onebusaway/alexa/util/CityUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/CityUtil.java
@@ -85,7 +85,7 @@ public class CityUtil {
                 .filter(r -> RegionUtils.isRegionUsable(r)
                         && (!r.getExperimental() || includeExperimentalRegions)
                         && r.getObaBaseUrl() != null)
-                .map(r -> String.format("%s, ", r.getName().replace(" (beta)", "")))
+                .map(r -> String.format("%s, ", SpeechUtil.formatRegionName(r.getName())))
                 .sorted()
                 .collect(Collectors.toList());
         // Some low-level manipulation to beautify the sequence of regions.

--- a/src/main/java/org/onebusaway/alexa/util/CityUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/CityUtil.java
@@ -21,6 +21,7 @@ import com.amazon.speech.ui.PlainTextOutputSpeech;
 import lombok.extern.log4j.Log4j;
 import org.onebusaway.alexa.SessionAttribute;
 import org.onebusaway.alexa.lib.ObaClient;
+import org.onebusaway.io.client.elements.ObaRegion;
 import org.onebusaway.io.client.util.RegionUtils;
 
 import java.io.IOException;
@@ -28,8 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.onebusaway.alexa.SessionAttribute.ASK_STATE;
-import static org.onebusaway.alexa.SessionAttribute.STOP_ID;
+import static org.onebusaway.alexa.SessionAttribute.*;
 
 /**
  * Utilities for setting up the region/city for a OneBusAway Alexa user
@@ -43,7 +43,8 @@ public class CityUtil {
      * @param currentCityName the city name the user requested, or null if the user didn't say a city/region name
      * @return the response required to start the initial dialog with the user to select their city/region
      */
-    public static SpeechletResponse askForCity(Optional<String> currentCityName, ObaClient obaClient) {
+    public static SpeechletResponse askForCity(Optional<String> currentCityName, ObaClient obaClient, Session session) {
+        boolean experimentalRegions = (boolean) session.getAttribute(EXPERIMENTAL_REGIONS);
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
         if (!currentCityName.isPresent()) {
             out.setText("Welcome to OneBusAway! Let's set you up. " +
@@ -57,13 +58,11 @@ public class CityUtil {
                     "region near %s, the city you gave. ";
             String question = "Tell me again, what's the largest city near you?";
             try {
-                String allRegions = allRegionsSpoken(obaClient);
+                String allRegions = allRegionsSpoken(obaClient.getAllRegions(experimentalRegions), experimentalRegions);
                 out.setText(String.format(intro +
-                                "Supported regions include %s. " +
+                                allRegions +
                                 question,
-                        currentCityName.get(),
-                        allRegions
-                ));
+                        currentCityName.get()));
             } catch (IOException e) {
                 log.error("Error getting all regions: " + e);
                 out.setText(String.format(intro + question, currentCityName.get()));
@@ -75,17 +74,18 @@ public class CityUtil {
     /**
      * Returns the text for listing all supported regions to the user
      *
-     * @param obaClient client used to fetch all regions from the OBA Regions API
+     * @param regions a list of all ObaRegions
+     * @param includeExperimentalRegions true if experimental (beta) regions should be included, false if they should not
      * @return the text for listing all supported regions to the user
      * @throws IOException
      */
-    public static String allRegionsSpoken(ObaClient obaClient) throws IOException {
-        List<String> activeRegions = obaClient.getAllRegions()
+    public static String allRegionsSpoken(List<ObaRegion> regions, boolean includeExperimentalRegions) {
+        List<String> activeRegions = regions
                 .stream()
                 .filter(r -> RegionUtils.isRegionUsable(r)
-                        && !r.getExperimental()
+                        && (!r.getExperimental() || includeExperimentalRegions)
                         && r.getObaBaseUrl() != null)
-                .map(r -> String.format("%s, ", r.getName()))
+                .map(r -> String.format("%s, ", r.getName().replace(" (beta)", "")))
                 .sorted()
                 .collect(Collectors.toList());
         // Some low-level manipulation to beautify the sequence of regions.
@@ -98,7 +98,7 @@ public class CityUtil {
 
         String finalStr = activeRegions.stream().collect(Collectors.joining(""));
         log.debug("All regions spoken: " + finalStr);
-        return finalStr;
+        return String.format("Supported regions include %s. ", finalStr);
     }
 
     /**

--- a/src/main/java/org/onebusaway/alexa/util/SessionUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SessionUtil.java
@@ -4,6 +4,8 @@ import com.amazon.speech.speechlet.Session;
 import org.onebusaway.alexa.SessionAttribute;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 
+import java.util.Optional;
+
 import static org.onebusaway.alexa.SessionAttribute.*;
 
 /**
@@ -44,43 +46,56 @@ public class SessionUtil {
     }
 
     /**
-     * Populates the provided session with persisted user data, if the session attribute is empty
+     * Populates the provided session with persisted user data, if the session attribute is empty and if user data
+     * exists.  If user data does not exist, it populates the session with default values for preferences
      *
      * @param session
      */
-    public static void populateAttributes(Session session, ObaUserDataItem userData) {
+    public static void populateAttributes(Session session, Optional<ObaUserDataItem> userData) {
+        if (!userData.isPresent()) {
+            // There is no user data to populate the session with - assign defaults and return
+            session.setAttribute(CLOCK_TIME, 0L);
+            session.setAttribute(ANNOUNCED_INTRODUCTION, 0L);
+            session.setAttribute(ANNOUNCED_FEATURES_V1_1_0, 0L);
+            session.setAttribute(EXPERIMENTAL_REGIONS, false);
+            return;
+        }
+        // Populate with user
         if (session.getAttribute(CITY_NAME) == null) {
-            session.setAttribute(CITY_NAME, userData.getCity());
+            session.setAttribute(CITY_NAME, userData.get().getCity());
         }
         if (session.getAttribute(STOP_ID) == null) {
-            session.setAttribute(STOP_ID, userData.getStopId());
+            session.setAttribute(STOP_ID, userData.get().getStopId());
         }
         if (session.getAttribute(REGION_ID) == null) {
-            session.setAttribute(REGION_ID, userData.getRegionId());
+            session.setAttribute(REGION_ID, userData.get().getRegionId());
         }
         if (session.getAttribute(REGION_NAME) == null) {
-            session.setAttribute(REGION_NAME, userData.getRegionName());
+            session.setAttribute(REGION_NAME, userData.get().getRegionName());
         }
         if (session.getAttribute(OBA_BASE_URL) == null) {
-            session.setAttribute(OBA_BASE_URL, userData.getObaBaseUrl());
+            session.setAttribute(OBA_BASE_URL, userData.get().getObaBaseUrl());
         }
         if (session.getAttribute(PREVIOUS_RESPONSE) == null) {
-            session.setAttribute(PREVIOUS_RESPONSE, userData.getPreviousResponse());
+            session.setAttribute(PREVIOUS_RESPONSE, userData.get().getPreviousResponse());
         }
         if (session.getAttribute(LAST_ACCESS_TIME) == null) {
-            session.setAttribute(LAST_ACCESS_TIME, userData.getLastAccessTime());
+            session.setAttribute(LAST_ACCESS_TIME, userData.get().getLastAccessTime());
         }
         if (session.getAttribute(CLOCK_TIME) == null) {
-            session.setAttribute(CLOCK_TIME, userData.getSpeakClockTime());
+            session.setAttribute(CLOCK_TIME, userData.get().getSpeakClockTime());
         }
         if (session.getAttribute(TIME_ZONE) == null) {
-            session.setAttribute(TIME_ZONE, userData.getTimeZone());
+            session.setAttribute(TIME_ZONE, userData.get().getTimeZone());
         }
         if (session.getAttribute(ANNOUNCED_INTRODUCTION) == null) {
-            session.setAttribute(ANNOUNCED_INTRODUCTION, userData.getAnnouncedIntroduction());
+            session.setAttribute(ANNOUNCED_INTRODUCTION, userData.get().getAnnouncedIntroduction());
         }
         if (session.getAttribute(ANNOUNCED_FEATURES_V1_1_0) == null) {
-            session.setAttribute(ANNOUNCED_FEATURES_V1_1_0, userData.getAnnouncedFeaturesv1_1_0());
+            session.setAttribute(ANNOUNCED_FEATURES_V1_1_0, userData.get().getAnnouncedFeaturesv1_1_0());
+        }
+        if (session.getAttribute(EXPERIMENTAL_REGIONS) == null) {
+            session.setAttribute(EXPERIMENTAL_REGIONS, userData.get().isExperimentalRegions());
         }
     }
 }

--- a/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/SpeechUtil.java
@@ -144,22 +144,22 @@ public class SpeechUtil {
      * @return the goodbye response
      */
     public static SpeechletResponse goodbye() {
-        String output = String.format("Good-bye");
+        String output = "Good-bye";
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
         out.setText(output);
         return SpeechletResponse.newTellResponse(out);
     }
 
     public static SpeechletResponse getGeneralErrorMessage() {
-        String output = String.format("Sorry, something went wrong.  Please try it again and it might work.");
+        String output = "Sorry, something went wrong.  Please try it again and it might work.";
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
         out.setText(output);
         return SpeechletResponse.newTellResponse(out);
     }
 
     public static SpeechletResponse getCommunicationErrorMessage() {
-        String output = String.format("Sorry, something went wrong communicating with your region's OneBusAway server.  " +
-                "Please try it again and it might work.");
+        String output = "Sorry, something went wrong communicating with your region's OneBusAway server.  " +
+                "Please try it again and it might work.";
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
         out.setText(output);
         return SpeechletResponse.newTellResponse(out);
@@ -187,7 +187,7 @@ public class SpeechUtil {
      * @param session if session attribute ANNOUNCED_INTRODUCTION is 0 will return intro text, if is 1 will return empty string
      * @return intro text if session attribute ANNOUNCED_INTRODUCTION is 0, or empty string if is 1
      */
-    public static String getIntroductionText(Session session) {
+    static String getIntroductionText(Session session) {
         Long introductionText = null;
         Object introductionTextObject = session.getAttribute(SessionAttribute.ANNOUNCED_INTRODUCTION);
         if (introductionTextObject instanceof Integer) {
@@ -240,5 +240,15 @@ public class SpeechUtil {
         } else {
             return "";
         }
+    }
+
+    /**
+     * Formats a region name for speech, including removing "(beta)" from experimental region names
+     *
+     * @param regionName region name to format
+     * @return a region name formatted for speech, including removing "(beta)" from experimental region names
+     */
+    public static String formatRegionName(String regionName) {
+        return regionName.replace(" (beta)", "");
     }
 }

--- a/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
@@ -242,4 +242,32 @@ public class StorageUtil {
         out.setText(output);
         return SpeechletResponse.newTellResponse(out);
     }
+
+    /**
+     * Update if experimental regions should be included in available regions
+     *
+     * @param enableExperimentalRegions true if experimental regions should be enabled, false if they should be disabled
+     * @return a message to the user saying experimental regions are enabled or disabled, depending on enableExperimentalRegions
+     */
+    public static SpeechletResponse updateExperimentalRegions(boolean enableExperimentalRegions, Session session, ObaDao obaDao, ObaUserDataItem obaUserDataItem, ObaUserClient obaUserClient) throws SpeechletException {
+        // Update DAO
+        obaUserDataItem.setExperimentalRegions(enableExperimentalRegions);
+        obaDao.saveUserData(obaUserDataItem);
+
+        // Update session
+        session.setAttribute(EXPERIMENTAL_REGIONS, enableExperimentalRegions);
+
+        String allRegions = "";
+        try {
+            allRegions = CityUtil.allRegionsSpoken(obaUserClient.getAllRegions(enableExperimentalRegions), enableExperimentalRegions);
+        } catch (IOException e) {
+            log.error("Error getting all regions: " + e);
+        }
+
+        String output = String.format("Experimental regions are now %s. ", enableExperimentalRegions ? "enabled" : "disabled", allRegions);
+        StorageUtil.saveOutputForRepeat(output, obaDao, obaUserDataItem);
+        PlainTextOutputSpeech out = new PlainTextOutputSpeech();
+        out.setText(output);
+        return SpeechletResponse.newTellResponse(out);
+    }
 }

--- a/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
@@ -264,7 +264,7 @@ public class StorageUtil {
             log.error("Error getting all regions: " + e);
         }
 
-        String output = String.format("Experimental regions are now %s. ", enableExperimentalRegions ? "enabled" : "disabled", allRegions);
+        String output = String.format("Experimental regions are now %s. %s", enableExperimentalRegions ? "enabled" : "disabled", allRegions);
         StorageUtil.saveOutputForRepeat(output, obaDao, obaUserDataItem);
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
         out.setText(output);

--- a/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
@@ -103,7 +103,7 @@ public class StorageUtil {
 
         // Build the full text response to the user
         StringBuilder builder = new StringBuilder();
-        builder.append(String.format("Ok, your stop number is %s in the %s region. ", stopCode, region.getName()));
+        builder.append(String.format("Ok, your stop number is %s in the %s region. ", stopCode, SpeechUtil.formatRegionName(region.getName())));
         builder.append(SpeechUtil.getIntroductionText(session));
         builder.append(String.format("Right now, %s", arrivalInfoText));
         String outText = builder.toString();

--- a/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
+++ b/src/main/java/org/onebusaway/alexa/util/StorageUtil.java
@@ -89,6 +89,8 @@ public class StorageUtil {
             throw new SpeechletException(e);
         }
 
+        boolean experimentalRegions = (boolean) session.getAttribute(EXPERIMENTAL_REGIONS);
+
         // This code path is current used for the SetCityIntent if this isn't the users first time using the skill
         // And, we can't store HashMaps in sessions (they get converted to ArrayLists by Alexa)
         // So, try to get route filters from persisted data in case the user has previously set them
@@ -108,7 +110,7 @@ public class StorageUtil {
 
         createOrUpdateUser(session, cityName, stopId, region.getId(), region.getName(), region.getObaBaseUrl(), outText,
                 System.currentTimeMillis(), speakClockTime, timeZone, 1L,
-                1L, obaDao);
+                1L, experimentalRegions, obaDao);
 
         PlainTextOutputSpeech out = new PlainTextOutputSpeech();
         out.setText(outText);
@@ -134,7 +136,8 @@ public class StorageUtil {
      */
     public static void createOrUpdateUser(Session session, String cityName, String stopId, long regionId, String regionName,
                                           String regionObaBaseUrl, String previousResponse, long lastAccessTime,
-                                          long speakClockTime, TimeZone timeZone, long announcedIntroduction, long announcedFeaturesv1_1_0, ObaDao obaDao) {
+                                          long speakClockTime, TimeZone timeZone, long announcedIntroduction, long announcedFeaturesv1_1_0,
+                                          boolean experimentalRegions, ObaDao obaDao) {
         Optional<ObaUserDataItem> optUserData = obaDao.getUserData(session);
         if (optUserData.isPresent()) {
             ObaUserDataItem userData = optUserData.get();
@@ -149,6 +152,7 @@ public class StorageUtil {
             userData.setTimeZone(timeZone.getID());
             userData.setAnnouncedIntroduction(announcedIntroduction);
             userData.setAnnouncedFeaturesv1_1_0(announcedFeaturesv1_1_0);
+            userData.setExperimentalRegions(experimentalRegions);
             obaDao.saveUserData(userData);
         } else {
             ObaUserDataItem userData = new ObaUserDataItem(
@@ -165,6 +169,7 @@ public class StorageUtil {
                     new HashMap<>(),
                     announcedIntroduction,
                     announcedFeaturesv1_1_0,
+                    experimentalRegions,
                     null
             );
             obaDao.saveUserData(userData);

--- a/src/test/java/config/UnitTests.java
+++ b/src/test/java/config/UnitTests.java
@@ -62,7 +62,7 @@ public class UnitTests {
 
     @Bean
     public ObaUserDataItem testUserData() {
-        return new ObaUserDataItem("test-user-id", "Seattle", "test-stop-id", 1, "Puget Sound", "http://api.pugetsound.onebusaway.org/", "", System.currentTimeMillis(), 0, "America/Los_Angeles", new HashMap<>(), 0, 0, null);
+        return new ObaUserDataItem("test-user-id", "Seattle", "test-stop-id", 1, "Puget Sound", "http://api.pugetsound.onebusaway.org/", "", System.currentTimeMillis(), 0, "America/Los_Angeles", new HashMap<>(), 0L, 0L, false, null);
     }
 
     @Bean

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -237,7 +237,7 @@ public class AuthedSpeechletTest {
             result = Optional.of(testUserData);
         }};
 
-        SessionUtil.populateAttributes(session, testUserData);
+        SessionUtil.populateAttributes(session, Optional.of(testUserData));
 
         SpeechletResponse sr = authedSpeechlet.onLaunch(
                 launchRequest,
@@ -276,7 +276,8 @@ public class AuthedSpeechletTest {
             obaStop.getId(); result = newStopCode;
             obaUserClient.getStopFromCode(l, newStopCode); result = obaStopsArray;
 
-            obaClient.getClosestRegion(l); result = Optional.of(TEST_REGION_1);
+            obaClient.getClosestRegion(l, false);
+            result = Optional.of(TEST_REGION_1);
 
             obaDao.getUserData(session); result = Optional.of(testUserData);
         }};
@@ -334,7 +335,7 @@ public class AuthedSpeechletTest {
             obaUserClient.getStopFromCode(l, newStopCode);
             result = obaStopsArray;
 
-            obaClient.getClosestRegion(l);
+            obaClient.getClosestRegion(l, false);
             result = Optional.of(TEST_REGION_1);
 
             obaDao.getUserData(session);
@@ -379,7 +380,8 @@ public class AuthedSpeechletTest {
             l.setLongitude(-82.4764);
             result = Optional.of(l);
 
-            obaClient.getClosestRegion(l); result = Optional.of(TEST_REGION_1);
+            obaClient.getClosestRegion(l, false);
+            result = Optional.of(TEST_REGION_1);
         }};
 
         HashMap<String, Slot> slots = new HashMap<>();
@@ -696,7 +698,8 @@ public class AuthedSpeechletTest {
             result = stopName1;
             obaStop2.getName();
             result = stopName2;
-            obaClient.getClosestRegion(l); result = Optional.of(TEST_REGION_2);
+            obaClient.getClosestRegion(l, false);
+            result = Optional.of(TEST_REGION_2);
         }};
 
         HashMap<String, Slot> slots = new HashMap<>();
@@ -1169,7 +1172,7 @@ public class AuthedSpeechletTest {
 
     public void allIntents() throws SpeechletException, IOException, IllegalAccessException {
         new Expectations() {{
-            obaClient.getAllRegions();
+            obaClient.getAllRegions(false);
             ArrayList<ObaRegion> regions = new ArrayList<>(1);
             regions.add(TEST_REGION_1);
             regions.add(TEST_REGION_2);

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -68,7 +68,7 @@ public class AuthedSpeechletTest {
     static final LaunchRequest launchRequest = LaunchRequest.builder().withRequestId("test-req-id").build();
 
     private static final ObaRegion TEST_REGION_1 = new ObaRegionElement(
-            1,
+            0,
             "Tampa Bay",
             true,
             "http://api.tampa.onebusaway.org/api/",
@@ -83,7 +83,7 @@ public class AuthedSpeechletTest {
     );
 
     private static final ObaRegion TEST_REGION_2 = new ObaRegionElement(
-            2,
+            1,
             "Puget Sound",
             true,
             "http://test-oba-url.example.com",
@@ -98,7 +98,7 @@ public class AuthedSpeechletTest {
     );
 
     private static final ObaRegion TEST_REGION_3 = new ObaRegionElement(
-            2,
+            3,
             "Atlanta",
             true,
             "http://test-oba-url.example.com",
@@ -113,7 +113,7 @@ public class AuthedSpeechletTest {
     );
 
     private static final ObaRegion TEST_REGION_EXPERIMENTAL = new ObaRegionElement(
-            3,
+            7,
             "Boston (beta)",
             true,
             "http://test-oba-url.example.com",
@@ -124,6 +124,21 @@ public class AuthedSpeechletTest {
             true, true, true,
             "test-twitter",
             true,
+            "test-stop-info-url"
+    );
+
+    private static final ObaRegion TEST_REGION_NEW_YORK = new ObaRegionElement(
+            2,
+            "New York",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, false, true,
+            "test-twitter",
+            false,
             "test-stop-info-url"
     );
 
@@ -1206,6 +1221,7 @@ public class AuthedSpeechletTest {
         obaRegions.add(TEST_REGION_2);
         obaRegions.add(TEST_REGION_3);
         obaRegions.add(TEST_REGION_EXPERIMENTAL);
+        obaRegions.add(TEST_REGION_NEW_YORK);
 
         new Expectations() {{
             obaUserClient.getAllRegions(anyBoolean);
@@ -1226,7 +1242,9 @@ public class AuthedSpeechletTest {
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, containsString("Experimental regions are now enabled"));
+        assertThat(spoken, containsString(SpeechUtil.formatRegionName(TEST_REGION_1.getName())));
         assertThat(spoken, containsString(SpeechUtil.formatRegionName(TEST_REGION_EXPERIMENTAL.getName())));
+        assertThat(spoken, containsString(SpeechUtil.formatRegionName(TEST_REGION_NEW_YORK.getName())));
         assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), true);
         assertEquals(testUserData.isExperimentalRegions(), true);
     }
@@ -1238,6 +1256,7 @@ public class AuthedSpeechletTest {
         obaRegions.add(TEST_REGION_2);
         obaRegions.add(TEST_REGION_3);
         obaRegions.add(TEST_REGION_EXPERIMENTAL);
+        obaRegions.add(TEST_REGION_NEW_YORK);
 
         new Expectations() {{
             obaUserClient.getAllRegions(anyBoolean);
@@ -1258,7 +1277,9 @@ public class AuthedSpeechletTest {
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, containsString("Experimental regions are now disabled"));
+        assertThat(spoken, containsString(SpeechUtil.formatRegionName(TEST_REGION_1.getName())));
         assertFalse(spoken.contains(SpeechUtil.formatRegionName(TEST_REGION_EXPERIMENTAL.getName())));
+        assertFalse(spoken.contains(SpeechUtil.formatRegionName(TEST_REGION_NEW_YORK.getName())));
         assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), false);
         assertEquals(testUserData.isExperimentalRegions(), false);
     }

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -1225,7 +1225,7 @@ public class AuthedSpeechletTest {
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, containsString("Experimental regions are now enabled"));
-        assertThat(spoken, containsString("Boston"));
+        assertThat(spoken, containsString(TEST_REGION_EXPERIMENTAL.getName().replace(" (beta)", "")));
         assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), true);
         assertEquals(testUserData.isExperimentalRegions(), true);
     }
@@ -1257,7 +1257,7 @@ public class AuthedSpeechletTest {
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, containsString("Experimental regions are now disabled"));
-        assertFalse(spoken.contains("Boston"));
+        assertFalse(spoken.contains(TEST_REGION_EXPERIMENTAL.getName()));
         assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), false);
         assertEquals(testUserData.isExperimentalRegions(), false);
     }

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -33,6 +33,7 @@ import org.onebusaway.alexa.lib.ObaUserClient;
 import org.onebusaway.alexa.storage.ObaDao;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.alexa.util.SessionUtil;
+import org.onebusaway.alexa.util.SpeechUtil;
 import org.onebusaway.io.client.elements.*;
 import org.onebusaway.io.client.request.ObaArrivalInfoResponse;
 import org.onebusaway.io.client.request.ObaStopResponse;
@@ -1225,7 +1226,7 @@ public class AuthedSpeechletTest {
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, containsString("Experimental regions are now enabled"));
-        assertThat(spoken, containsString(TEST_REGION_EXPERIMENTAL.getName().replace(" (beta)", "")));
+        assertThat(spoken, containsString(SpeechUtil.formatRegionName(TEST_REGION_EXPERIMENTAL.getName())));
         assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), true);
         assertEquals(testUserData.isExperimentalRegions(), true);
     }
@@ -1257,7 +1258,7 @@ public class AuthedSpeechletTest {
         );
         String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
         assertThat(spoken, containsString("Experimental regions are now disabled"));
-        assertFalse(spoken.contains(TEST_REGION_EXPERIMENTAL.getName()));
+        assertFalse(spoken.contains(SpeechUtil.formatRegionName(TEST_REGION_EXPERIMENTAL.getName())));
         assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), false);
         assertEquals(testUserData.isExperimentalRegions(), false);
     }

--- a/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
+++ b/src/test/java/org/onebusaway/alexa/AuthedSpeechletTest.java
@@ -96,6 +96,36 @@ public class AuthedSpeechletTest {
             "test-stop-info-url"
     );
 
+    private static final ObaRegion TEST_REGION_3 = new ObaRegionElement(
+            2,
+            "Atlanta",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, true, true,
+            "test-twitter",
+            false,
+            "test-stop-info-url"
+    );
+
+    private static final ObaRegion TEST_REGION_EXPERIMENTAL = new ObaRegionElement(
+            3,
+            "Boston (beta)",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, true, true,
+            "test-twitter",
+            true,
+            "test-stop-info-url"
+    );
+
     @Mocked
     ObaArrivalInfo obaArrivalInfo;
 
@@ -1163,6 +1193,56 @@ public class AuthedSpeechletTest {
             obaUserClient.getStop(anyString);
             result = obaStopResponse;
         }};
+    }
+
+    @Test
+    public void enableExperimentalRegions() throws SpeechletException {
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(ENABLE_EXPERIMENTAL_REGIONS)
+                                        .withSlots(new HashMap<String, Slot>())
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, containsString("Experimental regions are now enabled"));
+        assertEquals((long) session.getAttribute(EXPERIMENTAL_REGIONS), true);
+        assertEquals(testUserData.isExperimentalRegions(), true);
+    }
+
+    @Test
+    public void disableExperimentalRegions() throws SpeechletException, IOException {
+        new Expectations() {{
+            obaClient.getAllRegions(false);
+            ArrayList<ObaRegion> regions = new ArrayList<>(1);
+            regions.add(TEST_REGION_1);
+            regions.add(TEST_REGION_2);
+            regions.add(TEST_REGION_3);
+            regions.add(TEST_REGION_EXPERIMENTAL);
+            result = regions;
+        }};
+
+        SpeechletResponse sr = authedSpeechlet.onIntent(
+                IntentRequest.builder()
+                        .withRequestId("test-request-id")
+                        .withIntent(
+                                Intent.builder()
+                                        .withName(DISABLE_EXPERIMENTAL_REGIONS)
+                                        .withSlots(new HashMap<String, Slot>())
+                                        .build()
+                        )
+                        .build(),
+                session
+        );
+        String spoken = ((PlainTextOutputSpeech) sr.getOutputSpeech()).getText();
+        assertThat(spoken, containsString("Experimental regions are now disabled"));
+        assertEquals(session.getAttribute(EXPERIMENTAL_REGIONS), false);
+        assertEquals(testUserData.isExperimentalRegions(), false);
     }
 
     @Test

--- a/src/test/java/org/onebusaway/alexa/MainSpeechletEmptyTest.java
+++ b/src/test/java/org/onebusaway/alexa/MainSpeechletEmptyTest.java
@@ -198,7 +198,7 @@ public class MainSpeechletEmptyTest {
             l.setLongitude(-122.3331);
             result = Optional.of(l);
 
-            obaClient.getClosestRegion(l);
+            obaClient.getClosestRegion(l, false);
             result = Optional.of(TEST_REGION_1);
         }};
         HashMap<String, Slot> slots = new HashMap<>();
@@ -225,7 +225,7 @@ public class MainSpeechletEmptyTest {
     @Test
     public void unrecognizedCity() throws SpeechletException, IOException {
         new Expectations() {{
-            obaClient.getAllRegions();
+            obaClient.getAllRegions(false);
             ArrayList<ObaRegion> regions = new ArrayList<>(1);
             regions.add(TEST_REGION_1);
             regions.add(TEST_REGION_2);
@@ -314,7 +314,7 @@ public class MainSpeechletEmptyTest {
             l.setLongitude(-122.3331);
             result = Optional.of(l);
 
-            obaClient.getClosestRegion(l);
+            obaClient.getClosestRegion(l, false);
             result = Optional.of(TEST_REGION_1);
 
             obaStop.getStopCode();
@@ -374,7 +374,7 @@ public class MainSpeechletEmptyTest {
         String newStopCode = "2245";
 
         new Expectations() {{
-            obaClient.getAllRegions();
+            obaClient.getAllRegions(false);
             ArrayList<ObaRegion> regions = new ArrayList<>(1);
             regions.add(TEST_REGION_1);
             regions.add(TEST_REGION_2);
@@ -474,7 +474,7 @@ public class MainSpeechletEmptyTest {
     @Test
     public void allIntents() throws SpeechletException, IOException, IllegalAccessException {
         new Expectations() {{
-            obaClient.getAllRegions();
+            obaClient.getAllRegions(false);
             ArrayList<ObaRegion> regions = new ArrayList<>(1);
             regions.add(TEST_REGION_1);
             regions.add(TEST_REGION_2);

--- a/src/test/java/org/onebusaway/alexa/UtilTest.java
+++ b/src/test/java/org/onebusaway/alexa/UtilTest.java
@@ -52,7 +52,7 @@ public class UtilTest {
     Session session;
 
     private static final ObaRegion TEST_REGION_1 = new ObaRegionElement(
-            1,
+            0,
             "Tampa",
             true,
             "http://test-oba-url.example.com",
@@ -67,7 +67,7 @@ public class UtilTest {
     );
 
     private static final ObaRegion TEST_REGION_2 = new ObaRegionElement(
-            2,
+            1,
             "Puget Sound",
             true,
             "http://test-oba-url.example.com",
@@ -82,7 +82,7 @@ public class UtilTest {
     );
 
     private static final ObaRegion TEST_REGION_3 = new ObaRegionElement(
-            2,
+            3,
             "Atlanta",
             true,
             "http://test-oba-url.example.com",
@@ -97,7 +97,7 @@ public class UtilTest {
     );
 
     private static final ObaRegion TEST_REGION_EXPERIMENTAL = new ObaRegionElement(
-            3,
+            4,
             "Boston (beta)",
             true,
             "http://test-oba-url.example.com",
@@ -108,6 +108,21 @@ public class UtilTest {
             true, true, true,
             "test-twitter",
             true,
+            "test-stop-info-url"
+    );
+
+    private static final ObaRegion TEST_REGION_NEW_YORK = new ObaRegionElement(
+            2,
+            "New York",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, false, true,
+            "test-twitter",
+            false,
             "test-stop-info-url"
     );
 
@@ -175,12 +190,13 @@ public class UtilTest {
         regions.add(TEST_REGION_2);
         regions.add(TEST_REGION_3);
         regions.add(TEST_REGION_EXPERIMENTAL);
+        regions.add(TEST_REGION_NEW_YORK);
 
         String productionRegions = CityUtil.allRegionsSpoken(regions, false);
         assertEquals("Supported regions include Atlanta, Puget Sound, and Tampa. ", productionRegions);
 
         String allRegions = CityUtil.allRegionsSpoken(regions, true);
-        assertEquals("Supported regions include Atlanta, Boston, Puget Sound, and Tampa. ", allRegions);
+        assertEquals("Supported regions include Atlanta, Boston, New York, Puget Sound, and Tampa. ", allRegions);
     }
 
     @Test

--- a/src/test/java/org/onebusaway/alexa/UtilTest.java
+++ b/src/test/java/org/onebusaway/alexa/UtilTest.java
@@ -178,7 +178,7 @@ public class UtilTest {
         String productionRegions = CityUtil.allRegionsSpoken(regions, false);
         assertEquals("Supported regions include Atlanta, Puget Sound, and Tampa. ", productionRegions);
 
-        String allRegions = CityUtil.allRegionsSpoken(regions, false);
+        String allRegions = CityUtil.allRegionsSpoken(regions, true);
         assertEquals("Supported regions include Atlanta, Boston, Puget Sound, and Tampa. ", allRegions);
     }
 }

--- a/src/test/java/org/onebusaway/alexa/UtilTest.java
+++ b/src/test/java/org/onebusaway/alexa/UtilTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
 import org.onebusaway.alexa.util.CityUtil;
 import org.onebusaway.alexa.util.SessionUtil;
+import org.onebusaway.alexa.util.SpeechUtil;
 import org.onebusaway.io.client.elements.ObaRegion;
 import org.onebusaway.io.client.elements.ObaRegionElement;
 import org.springframework.test.annotation.DirtiesContext;
@@ -180,5 +181,14 @@ public class UtilTest {
 
         String allRegions = CityUtil.allRegionsSpoken(regions, true);
         assertEquals("Supported regions include Atlanta, Boston, Puget Sound, and Tampa. ", allRegions);
+    }
+
+    @Test
+    public void formatRegionNameForSpeech() {
+        String regionName = "Test region name";
+        String betaName = "Second region (beta)";
+
+        assertEquals("Test region name", SpeechUtil.formatRegionName(regionName));
+        assertEquals("Second region", SpeechUtil.formatRegionName(betaName));
     }
 }

--- a/src/test/java/org/onebusaway/alexa/UtilTest.java
+++ b/src/test/java/org/onebusaway/alexa/UtilTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.onebusaway.alexa.storage.ObaUserDataItem;
+import org.onebusaway.alexa.util.CityUtil;
 import org.onebusaway.alexa.util.SessionUtil;
 import org.onebusaway.io.client.elements.ObaRegion;
 import org.onebusaway.io.client.elements.ObaRegionElement;
@@ -33,7 +34,9 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import javax.annotation.Resource;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.onebusaway.alexa.SessionAttribute.*;
@@ -47,7 +50,22 @@ public class UtilTest {
     static final User testUser = User.builder().withUserId(TEST_USER_ID).build();
     Session session;
 
-    private static final ObaRegion TEST_REGION = new ObaRegionElement(
+    private static final ObaRegion TEST_REGION_1 = new ObaRegionElement(
+            1,
+            "Tampa",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, true, true,
+            "test-twitter",
+            false,
+            "test-stop-info-url"
+    );
+
+    private static final ObaRegion TEST_REGION_2 = new ObaRegionElement(
             2,
             "Puget Sound",
             true,
@@ -59,6 +77,36 @@ public class UtilTest {
             true, true, true,
             "test-twitter",
             false,
+            "test-stop-info-url"
+    );
+
+    private static final ObaRegion TEST_REGION_3 = new ObaRegionElement(
+            2,
+            "Atlanta",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, true, true,
+            "test-twitter",
+            false,
+            "test-stop-info-url"
+    );
+
+    private static final ObaRegion TEST_REGION_EXPERIMENTAL = new ObaRegionElement(
+            3,
+            "Boston (beta)",
+            true,
+            "http://test-oba-url.example.com",
+            "test-siri-url",
+            new ObaRegionElement.Bounds[0],
+            "test-lang",
+            "test-contact-email",
+            true, true, true,
+            "test-twitter",
+            true,
             "test-stop-info-url"
     );
 
@@ -85,9 +133,9 @@ public class UtilTest {
                 TEST_USER_ID,
                 "Puget Sound",
                 "6497",
-                TEST_REGION.getId(),
-                TEST_REGION.getName(),
-                TEST_REGION.getObaBaseUrl(),
+                TEST_REGION_2.getId(),
+                TEST_REGION_2.getName(),
+                TEST_REGION_2.getObaBaseUrl(),
                 "",
                 System.currentTimeMillis(),
                 0,
@@ -95,6 +143,7 @@ public class UtilTest {
                 new HashMap<>(),
                 1L,
                 1L,
+                false,
                 null
         );
 
@@ -103,7 +152,7 @@ public class UtilTest {
                 .withSessionId("test-session-id")
                 .build();
 
-        SessionUtil.populateAttributes(emptySession, userData);
+        SessionUtil.populateAttributes(emptySession, Optional.of(userData));
 
         assertEquals(userData.getRegionName(), emptySession.getAttribute(CITY_NAME));
         assertEquals(userData.getStopId(), emptySession.getAttribute(STOP_ID));
@@ -116,5 +165,20 @@ public class UtilTest {
         assertEquals(userData.getTimeZone(), emptySession.getAttribute(TIME_ZONE));
         assertEquals(userData.getAnnouncedIntroduction(), emptySession.getAttribute(ANNOUNCED_INTRODUCTION));
         assertEquals(userData.getAnnouncedFeaturesv1_1_0(), emptySession.getAttribute(ANNOUNCED_FEATURES_V1_1_0));
+    }
+
+    @Test
+    public void getRegionListText() {
+        ArrayList<ObaRegion> regions = new ArrayList<>();
+        regions.add(TEST_REGION_1);
+        regions.add(TEST_REGION_2);
+        regions.add(TEST_REGION_3);
+        regions.add(TEST_REGION_EXPERIMENTAL);
+
+        String productionRegions = CityUtil.allRegionsSpoken(regions, false);
+        assertEquals("Supported regions include Atlanta, Puget Sound, and Tampa. ", productionRegions);
+
+        String allRegions = CityUtil.allRegionsSpoken(regions, false);
+        assertEquals("Supported regions include Atlanta, Boston, Puget Sound, and Tampa. ", allRegions);
     }
 }


### PR DESCRIPTION
TODO:
- [x] Add intents and set values in ObaUserDataItem
- [x] Test boolean values?  My first initial conclusion that DynamoDB doesn't support booleans may have been incorrect.  What do we do going forward - leave Longs for legacy values, convert to booleans for new ones?
- [x] More unit tests for core experimental regions functionality
- [x] Fix tests!
- [x] Fix mention of experimental region names when setting city and stop that include "(beta)"
- [x] Add NYC as exception (requires changes to oba-client-library)